### PR TITLE
add(script): Added gitlab pipeline scripts for zfspv snapshot and clone

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -76,6 +76,18 @@ ZFS-VOLUME-PROVISION-PERCONA:
     - chmod 755 ./openebs-nativek8s/pipelines/stages/3-functional/ZFS-volume-provision-percona/ZFS-volume-provision-percona
     - ./openebs-nativek8s/pipelines/stages/3-functional/ZFS-volume-provision-percona/ZFS-volume-provision-percona
     
+ZFSPV-SNAPSHOT:
+  extends: .func_test_template
+  script:
+    - chmod 755 ./openebs-nativek8s/pipelines/stages/3-functional/ZFSPV-snapshot/ZFSPV-snapshot
+    - ./openebs-nativek8s/pipelines/stages/3-functional/ZFSPV-snapshot/ZFSPV-snapshot
+
+ZFSPV-CLONE:
+  extends: .func_test_template
+  script:
+    - chmod 755 ./openebs-nativek8s/pipelines/stages/3-functional/ZFSPV-clone/ZFSPV-clone
+    - ./openebs-nativek8s/pipelines/stages/3-functional/ZFSPV-clone/ZFSPV-clone
+    
 ##################################
 
 .cleanup_test_template:

--- a/openebs-nativek8s/pipelines/stages/2-Infra-setup/create-striped-pool/create-striped-pool
+++ b/openebs-nativek8s/pipelines/stages/2-Infra-setup/create-striped-pool/create-striped-pool
@@ -1,5 +1,4 @@
 #!/bin/bash
-set -x
 pod() {
 sshpass -p $pass ssh -o StrictHostKeyChecking=no $user@$ip -p $port 'cd e2e-nativek8s && bash openebs-nativek8s/pipelines/stages/2-Infra-setup/create-striped-pool/create-striped-pool node '"'$CI_JOB_ID'"'' '"'$CI_PIPELINE_ID'"' '"'$CI_COMMIT_SHA'"' '"'$RELEASE_TAG'"'
 

--- a/openebs-nativek8s/pipelines/stages/2-Infra-setup/deploy-openebs/deploy-openebs
+++ b/openebs-nativek8s/pipelines/stages/2-Infra-setup/deploy-openebs/deploy-openebs
@@ -1,5 +1,4 @@
 #!/bin/bash
-set -x
 pod() {
 sshpass -p $pass ssh -o StrictHostKeyChecking=no $user@$ip -p $port 'cd e2e-nativek8s && bash openebs-nativek8s/pipelines/stages/2-Infra-setup/deploy-openebs/deploy-openebs node '"'$CI_JOB_ID'"'' '"'$CI_PIPELINE_ID'"' '"'$CI_COMMIT_SHA'"' '"'$RELEASE_TAG'"' '"'$RELEASE_BRANCH'"' '"'$NDM_TAG'"' '"'$E_USER'"' '"'$E_PASSWORD'"'
 }
@@ -11,8 +10,6 @@ commit_id=$(echo $3)
 releaseTag=$(echo $4)
 releaseBranch=$(echo $5)
 ndmTag=$(echo $6)
-elastic_user=$(echo $7)
-elastic_password=$(echo $8)
 
 time="date"
 current_time=$(eval $time)

--- a/openebs-nativek8s/pipelines/stages/2-Infra-setup/storage-policies/openebs-sc
+++ b/openebs-nativek8s/pipelines/stages/2-Infra-setup/storage-policies/openebs-sc
@@ -1,5 +1,4 @@
 #!/bin/bash
-set -x
 pod() {
 sshpass -p $pass ssh -o StrictHostKeyChecking=no $user@$ip -p $port 'cd e2e-nativek8s && bash openebs-nativek8s/pipelines/stages/2-Infra-setup/storage-policies/openebs-sc node '"'$CI_JOB_ID'"'' '"'$CI_PIPELINE_ID'"' '"'$RELEASE_TAG'"'
 }

--- a/openebs-nativek8s/pipelines/stages/3-functional/ZFS-LocalPV-provisioner/ZFS-LocalPV-provisioner
+++ b/openebs-nativek8s/pipelines/stages/3-functional/ZFS-LocalPV-provisioner/ZFS-LocalPV-provisioner
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -x
+
 pod() {
 sshpass -p $pass ssh -o StrictHostKeyChecking=no $user@$ip -p $port 'cd e2e-nativek8s && bash openebs-nativek8s/pipelines/stages/3-functional/ZFS-LocalPV-provisioner/ZFS-LocalPV-provisioner node '"'$CI_JOB_ID'"'' '"'$CI_PIPELINE_ID'"' '"'$CI_COMMIT_SHA'"' '"'$RELEASE_TAG'"'
 
@@ -18,9 +18,11 @@ current_time=$(eval $time)
 
 echo "*******Deploy ZFS PV provisioner**************"
 
-bash openebs-nativek8s/utils/e2e-cr jobname:s3-j1-zfs-pv-provisioner jobphase:Waiting
+bash openebs-nativek8s/utils/e2e-cr jobname:s3-j1-zfspv-provisioner jobphase:Waiting
 bash openebs-nativek8s/utils/e2e-cr jobname:s3-j2-zfs-volume-provision-percona jobphase:Waiting
-bash openebs-nativek8s/utils/e2e-cr jobname:s3-j1-zfs-pv-provisioner jobphase:Running init_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id" openebs_version:"$releaseTag"
+bash openebs-nativek8s/utils/e2e-cr jobname:s3-j3-zfspv-snapshot jobphase:Waiting
+bash openebs-nativek8s/utils/e2e-cr jobname:s3-j4-zfspv-clone jobphase:Waiting
+bash openebs-nativek8s/utils/e2e-cr jobname:s3-j1-zfspv-provisioner jobphase:Running init_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id" openebs_version:"$releaseTag"
 
 test_name=$(bash openebs-nativek8s/utils/generate_test_name testcase=zfspv-provisioner metadata="")
 echo $test_name
@@ -37,6 +39,7 @@ sed -i -e '/name: STORAGE_CLASS/{n;s/.*/            value: zfs-sc/g}' \
 -e '/name: ACTION/{n;s/.*/            value: provision/g}' \
 -e '/name: COMPRESSION/{n;s/.*/            value: "off"/g}' \
 -e '/name: DEDUP/{n;s/.*/            value: "off"/g}' \
+-e '/name: SNAPSHOT_CLASS/{n;s/.*/            value: zfs-snapshot-class/g}' \
 -e '/name: RECORDSIZE/{n;s/.*/            value: 4k/g}' zfs_pv_provisioner.yml
 
 cat zfs_pv_provisioner.yml
@@ -44,7 +47,7 @@ cat zfs_pv_provisioner.yml
 bash ../openebs-nativek8s/utils/litmus_job_runner label='name:openebs-zfspv-provision' job=zfs_pv_provisioner.yml
 bash ../openebs-nativek8s/utils/dump_cluster_state;
 cd ..
-bash openebs-nativek8s/utils/event_updater jobname:s3-j1-zfs-pv-provisioner $test_name jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
+bash openebs-nativek8s/utils/event_updater jobname:s3-j1-zfspv-provisioner $test_name jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
 
 #################
 ## GET RESULT  ##
@@ -56,7 +59,7 @@ source ~/.profile
 testResult=$(kubectl get litmusresult ${test_name} --no-headers -o custom-columns=:spec.testStatus.result)
 
 current_time=$(eval $time)
-bash openebs-nativek8s/utils/e2e-cr jobname:s3-j1-zfs-pv-provisioner jobphase:Completed end_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id" openebs_version:"$releaseTag" test_result:$testResult
+bash openebs-nativek8s/utils/e2e-cr jobname:s3-j1-zfspv-provisioner jobphase:Completed end_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id" openebs_version:"$releaseTag" test_result:$testResult
 
 if [ "$rc_val" != "0" ]; then
 exit 1;

--- a/openebs-nativek8s/pipelines/stages/3-functional/ZFS-volume-provision-percona/ZFS-volume-provision-percona
+++ b/openebs-nativek8s/pipelines/stages/3-functional/ZFS-volume-provision-percona/ZFS-volume-provision-percona
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -x
+
 pod() {
 sshpass -p $pass ssh -o StrictHostKeyChecking=no $user@$ip -p $port 'cd e2e-nativek8s && bash openebs-nativek8s/pipelines/stages/3-functional/ZFS-volume-provision-percona/ZFS-volume-provision-percona node '"'$CI_JOB_ID'"'' '"'$CI_PIPELINE_ID'"' '"'$CI_COMMIT_SHA'"' '"'$RELEASE_TAG'"'
 
@@ -18,7 +18,7 @@ current_time=$(eval $time)
 
 echo "*******ZFS volume provision**************"
 
-bash openebs-nativek8s/utils/pooling jobname:s3-j1-zfs-pv-provisioner
+bash openebs-nativek8s/utils/pooling jobname:s3-j1-zfspv-provisioner
 bash openebs-nativek8s/utils/e2e-cr jobname:s3-j2-zfs-volume-provision-percona jobphase:Running init_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id" openebs_version:"$releaseTag"
 
 

--- a/openebs-nativek8s/pipelines/stages/3-functional/ZFSPV-clone/ZFSPV-clone
+++ b/openebs-nativek8s/pipelines/stages/3-functional/ZFSPV-clone/ZFSPV-clone
@@ -6,7 +6,7 @@ zfspv_clone_deprovision_rc_val=1
 zfspv_snapshot_deprovision_rc_val=1
 
 ## SSH into the cluster to run the kubernetes jobs for the experiments
-connect() {
+connect_cluster() {
 sshpass -p $pass ssh -o StrictHostKeyChecking=no $user@$ip -p $port 'cd e2e-nativek8s && bash openebs-nativek8s/pipelines/stages/3-functional/ZFSPV-clone/ZFSPV-clone run_job '"'$CI_JOB_ID'"'' '"'$CI_PIPELINE_ID'"' '"'$CI_COMMIT_SHA'"' '"'$RELEASE_TAG'"'
 
 }
@@ -226,7 +226,7 @@ fi
 }
 
 
-if [ "$1" == "node" ];then
+if [ "$1" == "run_job" ];then
   zfspv_clone $2 $3 $4 $5
   zfspv_clone_deprovision
   zfspv_snapshot_deprovision

--- a/openebs-nativek8s/pipelines/stages/3-functional/ZFSPV-clone/ZFSPV-clone
+++ b/openebs-nativek8s/pipelines/stages/3-functional/ZFSPV-clone/ZFSPV-clone
@@ -4,7 +4,7 @@ zfs_clone_rc_val=1
 zfs_clone_deprovision_rc_val=1
 zfs_snap_deprovision_rc_val=1
 
-pod() {
+connect() {
 sshpass -p $pass ssh -o StrictHostKeyChecking=no $user@$ip -p $port 'cd e2e-nativek8s && bash openebs-nativek8s/pipelines/stages/3-functional/ZFSPV-clone/ZFSPV-clone node '"'$CI_JOB_ID'"'' '"'$CI_PIPELINE_ID'"' '"'$CI_COMMIT_SHA'"' '"'$RELEASE_TAG'"'
 
 }
@@ -218,5 +218,5 @@ if [ "$1" == "node" ];then
   zfs_snap_deprovision
   app_deprovision
 else
-  pod
+  connect
 fi

--- a/openebs-nativek8s/pipelines/stages/3-functional/ZFSPV-clone/ZFSPV-clone
+++ b/openebs-nativek8s/pipelines/stages/3-functional/ZFSPV-clone/ZFSPV-clone
@@ -1,0 +1,222 @@
+#!/bin/bash
+
+zfs_clone_rc_val=1
+zfs_clone_deprovision_rc_val=1
+zfs_snap_deprovision_rc_val=1
+
+pod() {
+sshpass -p $pass ssh -o StrictHostKeyChecking=no $user@$ip -p $port 'cd e2e-nativek8s && bash openebs-nativek8s/pipelines/stages/3-functional/ZFSPV-clone/ZFSPV-clone node '"'$CI_JOB_ID'"'' '"'$CI_PIPELINE_ID'"' '"'$CI_COMMIT_SHA'"' '"'$RELEASE_TAG'"'
+
+}
+
+####################
+# create zfs-clone #
+####################
+
+zfs_clone() {
+
+job_id=$(echo $1)
+pipeline_id=$(echo $2)
+commit_id=$(echo $3)
+releaseTag=$(echo $4)
+source ~/.profile
+
+time="date"
+current_time=$(eval $time)
+
+## Pooling over the previous job to wait for its completion
+bash openebs-nativek8s/utils/pooling jobname:s3-j3-zfspv-snapshot
+bash openebs-nativek8s/utils/e2e-cr jobname:s3-j4-zfspv-clone jobphase:Running init_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id" openebs_version:"$releaseTag"
+
+## Creating clone for the snapshot created in the previous job
+test_name=$(bash openebs-nativek8s/utils/generate_test_name testcase=zfspv-clone metadata="")
+echo $test_name
+cd litmus
+
+# copy the content of run_litmus_test.yml into a different file to update the test specific parameters.
+cp experiments/functional/zfs-LocalPV/zfspv-clone/run_litmus_test.yml zfs_clone_test.yml
+
+# Modify test specific values in runner file using sed command
+sed -i -e '/name: APP_NAMESPACE/{n;s/.*/            value: percona-zfs-snap/}' \
+-e '/name: OPERATOR_NAMESPACE/{n;s/.*/            value: openebs/}' \
+-e '/name: STORAGE_CLASS/{n;s/.*/            value: zfs-sc/}' \
+-e '/name: SNAPSHOT_NAME/{n;s/.*/            value: zfs-snapshot/}' \
+-e '/name: CLONED_PVC_NAME/{n;s/.*/            value: clone-pvc/}' \
+-e '/name: CLONE_PVC_SIZE/{n;s/.*/            value: 5Gi/}' \
+-e '/name: APP_NAME/{n;s/.*/            value: percona/}' \
+-e '/name: APP_LABEL/{n;s/.*/            value: percona-clone/}' \
+-e '/name: DATA_PERSISTENCE/{n;s/.*/            value: mysql/}' zfs_clone_test.yml
+
+cat zfs_clone_test.yml
+
+bash ../openebs-nativek8s/utils/litmus_job_runner label='name:zfspv-clone' job=zfs_clone_test.yml
+bash ../openebs-nativek8s/utils/dump_cluster_state;
+cd ..
+bash openebs-nativek8s/utils/event_updater jobname:s3-j4-zfspv-clone $test_name jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
+
+zfs_clone_rc_val=$(echo $?)
+
+if [ "$zfs_clone_rc_val" != "0" ]; then
+zfs_snap_deprovision
+app_deprovision
+fi
+
+}
+
+#########################
+# Deprovision zfs-clone #
+#########################
+
+zfs_clone_deprovision() {
+
+run_id="deprovision";test_name=$(bash openebs-nativek8s/utils/generate_test_name testcase=zfspv-clone metadata=${run_id})
+echo $test_name
+cd litmus
+
+# copy the content of run_litmus_test.yml into a different file to update the test specific parameters.
+cp experiments/functional/zfs-LocalPV/zfspv-clone/run_litmus_test.yml zfs_clone_deprovision.yml
+
+# Modify test specific values in runner file using sed command
+sed -i -e 's/generateName: zfspv-clone-/generateName: zfspv-clone-deprovision-/g' \
+-e '/labels:/{n;s/  name: zfspv-clone/  name: zfspv-clone-deprovision/g}' \
+-e '/name: APP_NAMESPACE/{n;s/.*/            value: percona-zfs-snap/}' \
+-e '/name: OPERATOR_NAMESPACE/{n;s/.*/            value: openebs/}' \
+-e '/name: STORAGE_CLASS/{n;s/.*/            value: zfs-sc/}' \
+-e '/name: SNAPSHOT_NAME/{n;s/.*/            value: zfs-snapshot/}' \
+-e '/name: CLONED_PVC_NAME/{n;s/.*/            value: clone-pvc/}' \
+-e '/name: CLONE_PVC_SIZE/{n;s/.*/            value: 5Gi/}' \
+-e '/name: APP_NAME/{n;s/.*/            value: percona/}' \
+-e '/name: APP_LABEL/{n;s/.*/            value: percona-clone/}' \
+-e '/name: ACTION/{n;s/.*/            value: deprovision/}' \
+-e '/name: DATA_PERSISTENCE/{n;s/.*/            value: mysql/}' zfs_clone_deprovision.yml
+
+sed -i '/command:/i \
+          - name: RUN_ID\
+            value: '"$run_id"'\
+' zfs_clone_deprovision.yml
+
+cat zfs_clone_deprovision.yml
+
+bash ../openebs-nativek8s/utils/litmus_job_runner label='name:zfspv-clone-deprovision' job=zfs_clone_deprovision.yml
+bash ../openebs-nativek8s/utils/dump_cluster_state;
+cd ..
+bash openebs-nativek8s/utils/event_updater jobname:s3-j4-zfspv-clone $test_name jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
+
+zfs_clone_deprovision_rc_val=$(echo $?)
+
+if [ "$zfs_clone_deprovision_rc_val" != "0" ]; then
+zfs_snap_deprovision
+app_deprovision
+fi
+
+}
+
+############################
+# Deprovision zfs-snapshot #
+############################
+
+zfs_snap_deprovision() {
+
+run_id="deprovision";test_name=$(bash openebs-nativek8s/utils/generate_test_name testcase=zfspv-snapshot metadata=${run_id})
+echo $test_name
+cd litmus
+
+# copy the content of provisioner run_litmus_test.yml into a different file to update the test specific parameters.
+cp experiments/functional/zfs-LocalPV/zfspv-snapshot/run_litmus_test.yml zfs_snap_deprovision.yml
+
+# Modify test specific values in runner file using sed command
+sed -i -e 's/generateName: zfspv-snapshot-/generateName: zfspv-snapshot-deprovision-/g' \
+-e '/labels:/{n;s/  name: zfspv-snapshot/  name: zfspv-snapshot-deprovision/g}' \
+-e '/name: APP_NAMESPACE/{n;s/.*/            value: percona-zfs-snap/}' \
+-e '/name: OPERATOR_NAMESPACE/{n;s/.*/            value: openebs/}' \
+-e '/name: SNAPSHOT_CLASS/{n;s/.*/            value: zfs-snapshot-class/}' \
+-e '/name: SNAPSHOT_NAME/{n;s/.*/            value: zfs-snapshot/}' \
+-e '/name: APP_PVC/{n;s/.*/            value: percona-mysql-claim/}' \
+-e '/name: APP_LABEL/{n;s/.*/            value: name=percona/}' \
+-e '/name: ACTION/{n;s/.*/            value: deprovision/}' \
+-e '/name: DATA_PERSISTENCE/{n;s/.*/            value: mysql/}' zfs_snap_deprovision.yml
+
+sed -i '/command:/i \
+          - name: RUN_ID\
+            value: '"$run_id"'\
+' zfs_snap_deprovision.yml
+
+cat zfs_snap_deprovision.yml
+
+bash ../openebs-nativek8s/utils/litmus_job_runner label='name:zfspv-snapshot-deprovision' job=zfs_snap_deprovision.yml
+bash ../openebs-nativek8s/utils/dump_cluster_state;
+cd ..
+bash openebs-nativek8s/utils/event_updater jobname:s3-j4-zfspv-clone $test_name jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
+
+zfs_snap_deprovision_rc_val=$(echo $?)
+
+if [ "$zfs_snap_deprovision_rc_val" != "0" ]; then
+app_deprovision
+fi
+
+}
+
+##########################
+# Deprovision Application#
+##########################
+
+app_deprovision() {
+  
+run_id="snap-deprovision";test_name=$(bash openebs-nativek8s/utils/generate_test_name testcase=percona-deployment metadata=${run_id})
+echo $test_name
+cd litmus
+
+# copy the content of run_litmus_test.yml into a different file to update the test specific parameters.
+cp apps/percona/deployers/run_litmus_test.yml percona_deprovision.yml
+
+# Modify test specific values in runner file using sed command
+sed -i -e 's/app: percona-deployment/app: deprovision-percona-zfs-snap/g' \
+-e 's/generateName: litmus-percona-/generateName: litmus-percona-zfssnap-deprovision-/g' \
+-e 's/value: openebs-standard/value: zfs-sc/g' \
+-e 's/value: provision/value: deprovision/g' \
+-e '/name: TARGET_AFFINITY_CHECK/{n;s/value: enable/value: disable/g}' \
+-e 's/value: app-percona-ns/value: percona-zfs-snap/g' percona_deprovision.yml
+
+sed -i '/command:/i \
+          - name: RUN_ID\
+            value: '"$run_id"'\
+' percona_deprovision.yml
+
+cat percona_deprovision.yml
+
+bash ../openebs-nativek8s/utils/litmus_job_runner label='app:deprovision-percona-zfs-snap' job=percona_deprovision.yml
+bash ../openebs-nativek8s/utils/dump_cluster_state;
+cd ..
+bash openebs-nativek8s/utils/event_updater jobname:s3-j4-zfspv-clone $test_name jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
+
+app_deprovision_rc_val=$(echo $?)
+
+if [ "$app_deprovision_rc_val" -eq "0" ] &&
+   [ "$zfs_snap_deprovision_rc_val" -eq "0" ] &&
+   [ "$zfs_clone_deprovision_rc_val" -eq "0" ] &&
+   [ "$zfs_clone_rc_val" -eq "0" ]; then
+
+bash openebs-nativek8s/utils/e2e-cr jobname:s3-j4-zfspv-clone jobphase:Completed end_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id" openebs_version:"$releaseTag" test_result:Pass
+exit 1;
+
+fi
+
+if [ "$app_deprovision_rc_val" != "0" ]; then
+bash openebs-nativek8s/utils/e2e-cr jobname:s3-j4-zfspv-clone jobphase:Completed end_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id" openebs_version:"$releaseTag" test_result:Fail
+exit 1;
+else
+bash openebs-nativek8s/utils/e2e-cr jobname:s3-j4-zfspv-clone jobphase:Completed end_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id" openebs_version:"$releaseTag" test_result:Fail
+exit 1;
+fi
+
+}
+
+
+if [ "$1" == "node" ];then
+  zfs_clone $2 $3 $4 $5
+  zfs_clone_deprovision
+  zfs_snap_deprovision
+  app_deprovision
+else
+  pod
+fi

--- a/openebs-nativek8s/pipelines/stages/3-functional/ZFSPV-clone/ZFSPV-clone
+++ b/openebs-nativek8s/pipelines/stages/3-functional/ZFSPV-clone/ZFSPV-clone
@@ -1,19 +1,21 @@
 #!/bin/bash
 
-zfs_clone_rc_val=1
-zfs_clone_deprovision_rc_val=1
-zfs_snap_deprovision_rc_val=1
+## Define and initialize test-result specific variables.
+zfspv_clone_rc_val=1
+zfspv_clone_deprovision_rc_val=1
+zfspv_snapshot_deprovision_rc_val=1
 
+## SSH into the cluster to run the kubernetes jobs for the experiments
 connect() {
-sshpass -p $pass ssh -o StrictHostKeyChecking=no $user@$ip -p $port 'cd e2e-nativek8s && bash openebs-nativek8s/pipelines/stages/3-functional/ZFSPV-clone/ZFSPV-clone node '"'$CI_JOB_ID'"'' '"'$CI_PIPELINE_ID'"' '"'$CI_COMMIT_SHA'"' '"'$RELEASE_TAG'"'
+sshpass -p $pass ssh -o StrictHostKeyChecking=no $user@$ip -p $port 'cd e2e-nativek8s && bash openebs-nativek8s/pipelines/stages/3-functional/ZFSPV-clone/ZFSPV-clone run_job '"'$CI_JOB_ID'"'' '"'$CI_PIPELINE_ID'"' '"'$CI_COMMIT_SHA'"' '"'$RELEASE_TAG'"'
 
 }
 
-####################
-# create zfs-clone #
-####################
+######################
+# create zfspv-clone #
+######################
 
-zfs_clone() {
+zfspv_clone() {
 
 job_id=$(echo $1)
 pipeline_id=$(echo $2)
@@ -28,7 +30,7 @@ current_time=$(eval $time)
 bash openebs-nativek8s/utils/pooling jobname:s3-j3-zfspv-snapshot
 bash openebs-nativek8s/utils/e2e-cr jobname:s3-j4-zfspv-clone jobphase:Running init_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id" openebs_version:"$releaseTag"
 
-## Creating clone for the snapshot created in the previous job
+## Generate the test name to run litmusbook for creating zfspv-clone
 test_name=$(bash openebs-nativek8s/utils/generate_test_name testcase=zfspv-clone metadata="")
 echo $test_name
 cd litmus
@@ -49,26 +51,30 @@ sed -i -e '/name: APP_NAMESPACE/{n;s/.*/            value: percona-zfs-snap/}' \
 
 cat zfs_clone_test.yml
 
+## Run the Litmus job and get the details of the litmus job from litmus_job_runner utils.
 bash ../openebs-nativek8s/utils/litmus_job_runner label='name:zfspv-clone' job=zfs_clone_test.yml
+## Get the cluster state Once the litmus jobs completed.
 bash ../openebs-nativek8s/utils/dump_cluster_state;
 cd ..
+## Update the e2e event for the job.
 bash openebs-nativek8s/utils/event_updater jobname:s3-j4-zfspv-clone $test_name jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
 
-zfs_clone_rc_val=$(echo $?)
+zfspv_clone_rc_val=$(echo $?)
 
-if [ "$zfs_clone_rc_val" != "0" ]; then
-zfs_snap_deprovision
+if [ "$zfspv_clone_rc_val" != "0" ]; then
+zfspv_snapshot_deprovision
 app_deprovision
 fi
 
 }
 
-#########################
-# Deprovision zfs-clone #
-#########################
+###########################
+# Deprovision zfspv-clone #
+###########################
 
-zfs_clone_deprovision() {
+zfspv_clone_deprovision() {
 
+## Generate test name to run litmusbook for deprovisioning the zfspv clone
 run_id="deprovision";test_name=$(bash openebs-nativek8s/utils/generate_test_name testcase=zfspv-clone metadata=${run_id})
 echo $test_name
 cd litmus
@@ -97,26 +103,30 @@ sed -i '/command:/i \
 
 cat zfs_clone_deprovision.yml
 
+## Run the Litmus job and get the details of the litmus job from litmus_job_runner utils.
 bash ../openebs-nativek8s/utils/litmus_job_runner label='name:zfspv-clone-deprovision' job=zfs_clone_deprovision.yml
+## Get the cluster state Once the litmus jobs completed.
 bash ../openebs-nativek8s/utils/dump_cluster_state;
 cd ..
+## Update the e2e event for the job.
 bash openebs-nativek8s/utils/event_updater jobname:s3-j4-zfspv-clone $test_name jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
 
-zfs_clone_deprovision_rc_val=$(echo $?)
+zfspv_clone_deprovision_rc_val=$(echo $?)
 
-if [ "$zfs_clone_deprovision_rc_val" != "0" ]; then
-zfs_snap_deprovision
+if [ "$zfspv_clone_deprovision_rc_val" != "0" ]; then
+zfspv_snapshot_deprovision
 app_deprovision
 fi
 
 }
 
-############################
-# Deprovision zfs-snapshot #
-############################
+##############################
+# Deprovision zfspv-snapshot #
+##############################
 
-zfs_snap_deprovision() {
+zfspv_snapshot_deprovision() {
 
+## Generate test name to run litmusbook for deprovisioning the zfspv-snapshot
 run_id="deprovision";test_name=$(bash openebs-nativek8s/utils/generate_test_name testcase=zfspv-snapshot metadata=${run_id})
 echo $test_name
 cd litmus
@@ -143,14 +153,17 @@ sed -i '/command:/i \
 
 cat zfs_snap_deprovision.yml
 
+## Run the Litmus job and get the details of the litmus job from litmus_job_runner utils.
 bash ../openebs-nativek8s/utils/litmus_job_runner label='name:zfspv-snapshot-deprovision' job=zfs_snap_deprovision.yml
+## Get the cluster state Once the litmus jobs completed.
 bash ../openebs-nativek8s/utils/dump_cluster_state;
 cd ..
+## Update the e2e event for the job.
 bash openebs-nativek8s/utils/event_updater jobname:s3-j4-zfspv-clone $test_name jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
 
-zfs_snap_deprovision_rc_val=$(echo $?)
+zfspv_snapshot_deprovision_rc_val=$(echo $?)
 
-if [ "$zfs_snap_deprovision_rc_val" != "0" ]; then
+if [ "$zfspv_snapshot_deprovision_rc_val" != "0" ]; then
 app_deprovision
 fi
 
@@ -162,6 +175,7 @@ fi
 
 app_deprovision() {
   
+## Generate test name to run litmusbook for deprovisioning the percona application
 run_id="snap-deprovision";test_name=$(bash openebs-nativek8s/utils/generate_test_name testcase=percona-deployment metadata=${run_id})
 echo $test_name
 cd litmus
@@ -184,27 +198,27 @@ sed -i '/command:/i \
 
 cat percona_deprovision.yml
 
+## Run the Litmus job and get the details of the litmus job from litmus_job_runner utils.
 bash ../openebs-nativek8s/utils/litmus_job_runner label='app:deprovision-percona-zfs-snap' job=percona_deprovision.yml
+## Get the cluster state Once the litmus jobs completed.
 bash ../openebs-nativek8s/utils/dump_cluster_state;
 cd ..
+## Update the e2e event for the job.
 bash openebs-nativek8s/utils/event_updater jobname:s3-j4-zfspv-clone $test_name jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
 
 app_deprovision_rc_val=$(echo $?)
 
 if [ "$app_deprovision_rc_val" -eq "0" ] &&
-   [ "$zfs_snap_deprovision_rc_val" -eq "0" ] &&
-   [ "$zfs_clone_deprovision_rc_val" -eq "0" ] &&
-   [ "$zfs_clone_rc_val" -eq "0" ]; then
+   [ "$zfspv_snapshot_deprovision_rc_val" -eq "0" ] &&
+   [ "$zfspv_clone_deprovision_rc_val" -eq "0" ] &&
+   [ "$zfspv_clone_rc_val" -eq "0" ]; then
 
+## Update the e2e-result-custom-resources for the job
 bash openebs-nativek8s/utils/e2e-cr jobname:s3-j4-zfspv-clone jobphase:Completed end_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id" openebs_version:"$releaseTag" test_result:Pass
 exit 1;
 
-fi
-
-if [ "$app_deprovision_rc_val" != "0" ]; then
-bash openebs-nativek8s/utils/e2e-cr jobname:s3-j4-zfspv-clone jobphase:Completed end_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id" openebs_version:"$releaseTag" test_result:Fail
-exit 1;
 else
+## Update the e2e-result-custom-resources for the job
 bash openebs-nativek8s/utils/e2e-cr jobname:s3-j4-zfspv-clone jobphase:Completed end_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id" openebs_version:"$releaseTag" test_result:Fail
 exit 1;
 fi
@@ -213,10 +227,10 @@ fi
 
 
 if [ "$1" == "node" ];then
-  zfs_clone $2 $3 $4 $5
-  zfs_clone_deprovision
-  zfs_snap_deprovision
+  zfspv_clone $2 $3 $4 $5
+  zfspv_clone_deprovision
+  zfspv_snapshot_deprovision
   app_deprovision
 else
-  connect
+  connect_cluster
 fi

--- a/openebs-nativek8s/pipelines/stages/3-functional/ZFSPV-snapshot/ZFSPV-snapshot
+++ b/openebs-nativek8s/pipelines/stages/3-functional/ZFSPV-snapshot/ZFSPV-snapshot
@@ -1,11 +1,21 @@
 #!/bin/bash
 
-pod() {
-sshpass -p $pass ssh -o StrictHostKeyChecking=no $user@$ip -p $port 'cd e2e-nativek8s && bash openebs-nativek8s/pipelines/stages/3-functional/ZFSPV-snapshot/ZFSPV-snapshot node '"'$CI_JOB_ID'"'' '"'$CI_PIPELINE_ID'"' '"'$CI_COMMIT_SHA'"' '"'$RELEASE_TAG'"'
+## Define and initialize test-result specific variables.
+app_deploy_rc_val=1
+app_loadgen_rc_val=1
+zfspv_snapshot_rc_val=1
+
+## SSH into the cluster to run the kubernetes jobs for the experiments
+connect_cluster() {
+sshpass -p $pass ssh -o StrictHostKeyChecking=no $user@$ip -p $port 'cd e2e-nativek8s && bash openebs-nativek8s/pipelines/stages/3-functional/ZFSPV-snapshot/ZFSPV-snapshot run_job '"'$CI_JOB_ID'"'' '"'$CI_PIPELINE_ID'"' '"'$CI_COMMIT_SHA'"' '"'$RELEASE_TAG'"'
 
 }
 
-node() {
+#######################################
+# Deploy percona application on ZFSPV #
+#######################################
+
+app_deploy() {
 
 job_id=$(echo $1)
 pipeline_id=$(echo $2)
@@ -20,12 +30,7 @@ current_time=$(eval $time)
 bash openebs-nativek8s/utils/pooling jobname:s3-j1-zfspv-provisioner
 bash openebs-nativek8s/utils/e2e-cr jobname:s3-j3-zfspv-snapshot jobphase:Running init_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id" openebs_version:"$releaseTag"
 
-######################
-# Deploy Application #
-######################
-
-## Deploying percona application using zfs volume
-
+## Generate the test name for running the litmusbook for percona deployment
 run_id="zfs-snap";test_name=$(bash openebs-nativek8s/utils/generate_test_name testcase=percona-deployment metadata=${run_id})
 echo $test_name
 cd litmus
@@ -47,21 +52,28 @@ sed -i '/command:/i \
 
 cat deploy_percona_zfssnap.yml
 
+## Run the Litmus job and get the details of the litmus job from litmus_job_runner utils.
 bash ../openebs-nativek8s/utils/litmus_job_runner label='app:deploy-percona-zfs-snap' job=deploy_percona_zfssnap.yml
+## Get the cluster state Once the litmus jobs completed.
 bash ../openebs-nativek8s/utils/dump_cluster_state;
 cd ..
+## Update the e2e event for the job.
 bash openebs-nativek8s/utils/event_updater jobname:s3-j3-zfspv-snapshot $test_name jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
 
-if [ "$?" != "0" ]; then
+app_deploy_rc_val=$(echo $?)
+if [ "$app_deploy_rc_val" != "0" ]; then
 exit 1;
 fi
 
-################
-#   LoadGen    #
-################
+}
 
-## Load generation on the percona application
+###################################
+# Loadgen on Percona application  #
+###################################
 
+app_loadgen() {
+
+## Generate test name for running litmusbook for generate load on application
 run_id="zfs-snap";test_name=$(bash openebs-nativek8s/utils/generate_test_name testcase=percona-loadgen metadata=${run_id})
 echo $test_name
 cd litmus
@@ -81,21 +93,28 @@ sed -i '/command:/i \
 
 cat loadgen_percona_zfssnap.yml
 
+## Run the Litmus job and get the details of the litmus job from litmus_job_runner utils.
 bash ../openebs-nativek8s/utils/litmus_job_runner label='loadgen:percona-loadjob-zfs-snap' job=loadgen_percona_zfssnap.yml
+## Get the cluster state Once the litmus jobs completed.
 bash ../openebs-nativek8s/utils/dump_cluster_state;
 cd ..
+## Update the e2e event for the job.
 bash openebs-nativek8s/utils/event_updater jobname:s3-j3-zfspv-snapshot $test_name jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
 
-if [ "$?" != "0" ]; then
+app_loadgen_rc_val=$(echo $?)
+if [ "$app_loadgen_rc_val" != "0" ]; then
 exit 1;
 fi
 
-#######################
-# Create zfs-snapshot #
-#######################
+}
 
-## Litmus experiment for creating zfspv snapshot
+#########################
+# Create zfspv-snapshot #
+#########################
 
+zfspv_snapshot() { 
+  
+## Generate test name for running litmusbook for creating zfspv snapshot
 test_name=$(bash openebs-nativek8s/utils/generate_test_name testcase=zfspv-snapshot metadata="")
 echo $test_name
 cd litmus
@@ -120,34 +139,37 @@ sed -i '/parameters.yml: |/a \
 
 cat zfs_snap_test.yml
 
+## Run the Litmus job and get the details of the litmus job from litmus_job_runner utils.
 bash ../openebs-nativek8s/utils/litmus_job_runner label='name:zfspv-snapshot' job=zfs_snap_test.yml
+## Get the cluster state Once the litmus jobs completed.
 bash ../openebs-nativek8s/utils/dump_cluster_state;
 cd ..
+## Update the e2e event for the job.
 bash openebs-nativek8s/utils/event_updater jobname:s3-j3-zfspv-snapshot $test_name jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
 
-if [ "$?" != "0" ]; then
+zfspv_snapshot_rc_val=$(echo $?)
+
+if [ "$app_deploy_rc_val" -eq "0" ] &&
+   [ "$app_loadgen_rc_val" -eq "0" ] &&
+   [ "$zfspv_snapshot_rc_val" -eq "0" ]; then
+
+## Update the e2e-result-custom-resources for the job
+bash openebs-nativek8s/utils/e2e-cr jobname:s3-j3-zfspv-snapshot jobphase:Completed end_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id" openebs_version:"$releaseTag" test_result:Pass
+exit 1;
+
+else
+## Update the e2e-result-custom-resources for the job
+bash openebs-nativek8s/utils/e2e-cr jobname:s3-j3-zfspv-snapshot jobphase:Completed end_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id" openebs_version:"$releaseTag" test_result:Fail
 exit 1;
 fi
 
-#################
-## GET RESULT  ##
-#################
-
-rc_val=$(echo $?)
-
-source ~/.profile
-testResult=$(kubectl get litmusresult ${test_name} --no-headers -o custom-columns=:spec.testStatus.result)
-
-current_time=$(eval $time)
-bash openebs-nativek8s/utils/e2e-cr jobname:s3-j3-zfspv-snapshot jobphase:Completed end_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id" openebs_version:"$releaseTag" test_result:$testResult
-
-if [ "$rc_val" != "0" ]; then
-exit 1;
-fi
 }
 
-if [ "$1" == "node" ];then
-  node $2 $3 $4 $5
+
+if [ "$1" == "run_job" ];then
+  app_deploy $2 $3 $4 $5
+  app_loadgen
+  zfspv_snapshot
 else
-  pod
+  connect_cluster
 fi

--- a/openebs-nativek8s/pipelines/stages/3-functional/ZFSPV-snapshot/ZFSPV-snapshot
+++ b/openebs-nativek8s/pipelines/stages/3-functional/ZFSPV-snapshot/ZFSPV-snapshot
@@ -1,0 +1,153 @@
+#!/bin/bash
+
+pod() {
+sshpass -p $pass ssh -o StrictHostKeyChecking=no $user@$ip -p $port 'cd e2e-nativek8s && bash openebs-nativek8s/pipelines/stages/3-functional/ZFS-snapshot/ZFS-snapshot node '"'$CI_JOB_ID'"'' '"'$CI_PIPELINE_ID'"' '"'$CI_COMMIT_SHA'"' '"'$RELEASE_TAG'"'
+
+}
+
+node() {
+
+job_id=$(echo $1)
+pipeline_id=$(echo $2)
+commit_id=$(echo $3)
+releaseTag=$(echo $4)
+source ~/.profile
+
+time="date"
+current_time=$(eval $time)
+
+## Pooling over the previous job to wait for its completion
+bash openebs-nativek8s/utils/pooling jobname:s3-j1-zfspv-provisioner
+bash openebs-nativek8s/utils/e2e-cr jobname:s3-j3-zfspv-snapshot jobphase:Running init_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id" openebs_version:"$releaseTag"
+
+######################
+# Deploy Application #
+######################
+
+## Deploying percona application using zfs volume
+
+run_id="zfs-snap";test_name=$(bash openebs-nativek8s/utils/generate_test_name testcase=percona-deployment metadata=${run_id})
+echo $test_name
+cd litmus
+
+# copy the content of deployers run_litmus_test.yml into a different file to update the test specific parameters.
+cp apps/percona/deployers/run_litmus_test.yml deploy_percona_zfssnap.yml
+
+# Modify test specific values in runner file using sed command
+sed -i -e 's/app: percona-deployment/app: deploy-percona-zfs-snap/g' \
+-e 's/generateName: litmus-percona-/generateName: litmus-percona-zfssnap-/g' \
+-e 's/value: openebs-standard/value: zfs-sc/g' \
+-e '/name: TARGET_AFFINITY_CHECK/{n;s/value: enable/value: disable/g}' \
+-e 's/value: app-percona-ns/value: percona-zfs-snap/g' deploy_percona_zfssnap.yml
+
+sed -i '/command:/i \
+          - name: RUN_ID\
+            value: '"$run_id"'\
+' deploy_percona_zfssnap.yml
+
+cat deploy_percona_zfssnap.yml
+
+bash ../openebs-nativek8s/utils/litmus_job_runner label='app:deploy-percona-zfs-snap' job=deploy_percona_zfssnap.yml
+bash ../openebs-nativek8s/utils/dump_cluster_state;
+cd ..
+bash openebs-nativek8s/utils/event_updater jobname:s3-j3-zfspv-snapshot $test_name jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
+
+if [ "$?" != "0" ]; then
+exit 1;
+fi
+
+################
+#   LoadGen    #
+################
+
+## Load generation on the percona application
+
+run_id="zfs-snap";test_name=$(bash openebs-nativek8s/utils/generate_test_name testcase=percona-loadgen metadata=${run_id})
+echo $test_name
+cd litmus
+
+# copy the content of workload run_litmus_test.yml into a different file to update the test specific parameters.
+cp apps/percona/workload/run_litmus_test.yml loadgen_percona_zfssnap.yml
+
+# Modify test specific values in runner file using sed command
+sed -i -e 's/loadgen: percona-loadjob/loadgen: percona-loadjob-zfs-snap/g' \
+-e 's/generateName: percona-loadgen-/generateName: percona-loadgen-zfs-snap-/g' \
+-e 's/value: app-percona-ns/value: percona-zfs-snap/g' loadgen_percona_zfssnap.yml
+
+sed -i '/command:/i \
+          - name: RUN_ID\
+            value: '"$run_id"'\
+' loadgen_percona_zfssnap.yml
+
+cat loadgen_percona_zfssnap.yml
+
+bash ../openebs-nativek8s/utils/litmus_job_runner label='loadgen:percona-loadjob-zfs-snap' job=loadgen_percona_zfssnap.yml
+bash ../openebs-nativek8s/utils/dump_cluster_state;
+cd ..
+bash openebs-nativek8s/utils/event_updater jobname:s3-j3-zfspv-snapshot $test_name jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
+
+if [ "$?" != "0" ]; then
+exit 1;
+fi
+
+#######################
+# Create zfs-snapshot #
+#######################
+
+## Litmus experiment for creating zfspv snapshot
+
+test_name=$(bash openebs-nativek8s/utils/generate_test_name testcase=zfspv-snapshot metadata="")
+echo $test_name
+cd litmus
+
+# copy the content of run_litmus_test.yml into a different file to update the test specific parameters.
+cp experiments/functional/zfs-LocalPV/zfspv-snapshot/run_litmus_test.yml zfs_snap_test.yml
+
+# Modify test specific values in runner file using sed command
+sed -i -e '/name: APP_NAMESPACE/{n;s/.*/            value: percona-zfs-snap/}' \
+-e '/name: OPERATOR_NAMESPACE/{n;s/.*/            value: openebs/}' \
+-e '/name: SNAPSHOT_CLASS/{n;s/.*/            value: zfs-snapshot-class/}' \
+-e '/name: SNAPSHOT_NAME/{n;s/.*/            value: zfs-snapshot/}' \
+-e '/name: APP_PVC/{n;s/.*/            value: percona-mysql-claim/}' \
+-e '/name: APP_LABEL/{n;s/.*/            value: name=percona/}' \
+-e '/name: DATA_PERSISTENCE/{n;s/.*/            value: mysql/}' zfs_snap_test.yml
+
+sed -i '/parameters.yml: |/a \
+    dbuser: root\
+    dbpassword: k8sDem0\
+    dbname: zfs_snap
+' zfs_snap_test.yml
+
+cat zfs_snap_test.yml
+
+bash ../openebs-nativek8s/utils/litmus_job_runner label='name:zfspv-snapshot' job=zfs_snap_test.yml
+bash ../openebs-nativek8s/utils/dump_cluster_state;
+cd ..
+bash openebs-nativek8s/utils/event_updater jobname:s3-j3-zfspv-snapshot $test_name jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
+
+if [ "$?" != "0" ]; then
+exit 1;
+fi
+
+#################
+## GET RESULT  ##
+#################
+
+rc_val=$(echo $?)
+
+source ~/.profile
+testResult=$(kubectl get litmusresult ${test_name} --no-headers -o custom-columns=:spec.testStatus.result)
+
+current_time=$(eval $time)
+bash openebs-nativek8s/utils/e2e-cr jobname:s3-j3-zfspv-snapshot jobphase:Completed end_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id" openebs_version:"$releaseTag" test_result:$testResult
+
+if [ "$rc_val" != "0" ]; then
+exit 1;
+fi
+}
+
+if [ "$1" == "node" ];then
+  node $2 $3 $4 $5
+else
+  pod
+fi

--- a/openebs-nativek8s/pipelines/stages/3-functional/ZFSPV-snapshot/ZFSPV-snapshot
+++ b/openebs-nativek8s/pipelines/stages/3-functional/ZFSPV-snapshot/ZFSPV-snapshot
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 pod() {
-sshpass -p $pass ssh -o StrictHostKeyChecking=no $user@$ip -p $port 'cd e2e-nativek8s && bash openebs-nativek8s/pipelines/stages/3-functional/ZFS-snapshot/ZFS-snapshot node '"'$CI_JOB_ID'"'' '"'$CI_PIPELINE_ID'"' '"'$CI_COMMIT_SHA'"' '"'$RELEASE_TAG'"'
+sshpass -p $pass ssh -o StrictHostKeyChecking=no $user@$ip -p $port 'cd e2e-nativek8s && bash openebs-nativek8s/pipelines/stages/3-functional/ZFSPV-snapshot/ZFSPV-snapshot node '"'$CI_JOB_ID'"'' '"'$CI_PIPELINE_ID'"' '"'$CI_COMMIT_SHA'"' '"'$RELEASE_TAG'"'
 
 }
 

--- a/openebs-nativek8s/pipelines/stages/4-cleanup/cleanup-spc-striped-pool/cleanup-spc-striped-pool
+++ b/openebs-nativek8s/pipelines/stages/4-cleanup/cleanup-spc-striped-pool/cleanup-spc-striped-pool
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -x
+
 pod() {
 sshpass -p $pass ssh -o StrictHostKeyChecking=no $user@$ip -p $port 'cd e2e-nativek8s && bash openebs-nativek8s/pipelines/stages/4-cleanup/cleanup-spc-striped-pool/cleanup-spc-striped-pool node '"'$CI_JOB_ID'"'' '"'$CI_PIPELINE_ID'"' '"'$CI_COMMIT_SHA'"' '"'$RELEASE_TAG'"'
 

--- a/openebs-nativek8s/pipelines/stages/4-cleanup/cluster-cleanup/cluster-cleanup
+++ b/openebs-nativek8s/pipelines/stages/4-cleanup/cluster-cleanup/cluster-cleanup
@@ -4,8 +4,8 @@ pod() {
 echo $CI_JOB_ID
 ###clone e2e-nativek8s-repo
 echo "cloning e2e-nativek8s repo*************"
-sshpass -p $pass ssh -o StrictHostKeyChecking=no $user@$ip -p 1658 'git clone https://github.com/mayadata-io/e2e-nativek8s.git'
-sshpass -p $pass ssh -o StrictHostKeyChecking=no $user@$ip -p 1658 'cd e2e-nativek8s && git checkout release-branch && bash openebs-nativek8s/pipelines/stages/4-cleanup/cluster-cleanup/cluster-cleanup node '"'$CI_JOB_ID'"''
+sshpass -p $pass ssh -o StrictHostKeyChecking=no $user@$ip -p $port 'git clone https://github.com/mayadata-io/e2e-nativek8s.git'
+sshpass -p $pass ssh -o StrictHostKeyChecking=no $user@$ip -p $port 'cd e2e-nativek8s && git checkout release-branch && bash openebs-nativek8s/pipelines/stages/4-cleanup/cluster-cleanup/cluster-cleanup node '"'$CI_JOB_ID'"''
 }
 
 node() {

--- a/openebs-nativek8s/pipelines/stages/4-cleanup/openebs-uninstall/openebs-uninstall
+++ b/openebs-nativek8s/pipelines/stages/4-cleanup/openebs-uninstall/openebs-uninstall
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -x
+
 pod() {
 sshpass -p $pass ssh -o StrictHostKeyChecking=no $user@$ip -p $port 'cd e2e-nativek8s && bash openebs-nativek8s/pipelines/stages/4-cleanup/openebs-uninstall/openebs-uninstall node '"'$CI_JOB_ID'"'' '"'$CI_PIPELINE_ID'"' '"'$CI_COMMIT_SHA'"' '"'$RELEASE_TAG'"'
 }


### PR DESCRIPTION
Signed-off-by: Aman Gupta <aman.gupta@mayadata.io>

- Added gitlab scripts for zfspv-snapshot and clone creation jobs.
- Removed set -x command from all the jobs to hide confidential passwords and gitlab tokens.
- Implemented the new way for running bash scripts in pipeline.
  1. Now each job in a script will run as a bash function
  2. If One of the job fails in pipeline it will not directly exit from the point of failure, instead it will execute the next tasks which will be related to the deprovision of the previous task of the job.