### PR TITLE
Removed the exit 1 code after updating test result in e2e-cr as pass in zfspv clone and snapshot gitlab script

### DIFF
--- a/openebs-nativek8s/pipelines/stages/3-functional/ZFSPV-clone/ZFSPV-clone
+++ b/openebs-nativek8s/pipelines/stages/3-functional/ZFSPV-clone/ZFSPV-clone
@@ -215,7 +215,6 @@ if [ "$app_deprovision_rc_val" -eq "0" ] &&
 
 ## Update the e2e-result-custom-resources for the job
 bash openebs-nativek8s/utils/e2e-cr jobname:s3-j4-zfspv-clone jobphase:Completed end_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id" openebs_version:"$releaseTag" test_result:Pass
-exit 1;
 
 else
 ## Update the e2e-result-custom-resources for the job

--- a/openebs-nativek8s/pipelines/stages/3-functional/ZFSPV-snapshot/ZFSPV-snapshot
+++ b/openebs-nativek8s/pipelines/stages/3-functional/ZFSPV-snapshot/ZFSPV-snapshot
@@ -155,7 +155,6 @@ if [ "$app_deploy_rc_val" -eq "0" ] &&
 
 ## Update the e2e-result-custom-resources for the job
 bash openebs-nativek8s/utils/e2e-cr jobname:s3-j3-zfspv-snapshot jobphase:Completed end_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id" openebs_version:"$releaseTag" test_result:Pass
-exit 1;
 
 else
 ## Update the e2e-result-custom-resources for the job


### PR DESCRIPTION
Signed-off-by: Aman Gupta <aman.gupta@mayadata.io>

- Remoed exit 1 command after updating e2e-cr as pass
- Previously it was getting exit with error code `exit 1` but test was passed