### PR TITLE
refactor(Script): Resolved the function name mismatch issue in zfspv-provisioner test

### DIFF
--- a/openebs-nativek8s/pipelines/stages/3-functional/ZFS-LocalPV-provisioner/ZFS-LocalPV-provisioner
+++ b/openebs-nativek8s/pipelines/stages/3-functional/ZFS-LocalPV-provisioner/ZFS-LocalPV-provisioner
@@ -80,6 +80,6 @@ fi
 if [ "$1" == "run_job" ];then
   run_job $2 $3 $4 $5
 else
-  pod
+  connect_cluster
 fi
 

--- a/openebs-nativek8s/pipelines/stages/3-functional/ZFSPV-clone/ZFSPV-clone
+++ b/openebs-nativek8s/pipelines/stages/3-functional/ZFSPV-clone/ZFSPV-clone
@@ -32,7 +32,7 @@ bash openebs-nativek8s/utils/e2e-cr jobname:s3-j4-zfspv-clone jobphase:Running i
 ## Generate the test name to run litmusbook for creating zfspv-clone
 test_name=$(bash openebs-nativek8s/utils/generate_test_name testcase=zfspv-clone metadata="")
 echo $test_name
-cd litmus
+cd e2e-tests
 
 # copy the content of run_litmus_test.yml into a different file to update the test specific parameters.
 cp experiments/functional/zfs-LocalPV/zfspv-clone/run_litmus_test.yml zfs_clone_test.yml
@@ -76,7 +76,7 @@ zfspv_clone_deprovision() {
 ## Generate test name to run litmusbook for deprovisioning the zfspv clone
 run_id="deprovision";test_name=$(bash openebs-nativek8s/utils/generate_test_name testcase=zfspv-clone metadata=${run_id})
 echo $test_name
-cd litmus
+cd e2e-tests
 
 # copy the content of run_litmus_test.yml into a different file to update the test specific parameters.
 cp experiments/functional/zfs-LocalPV/zfspv-clone/run_litmus_test.yml zfs_clone_deprovision.yml
@@ -128,7 +128,7 @@ zfspv_snapshot_deprovision() {
 ## Generate test name to run litmusbook for deprovisioning the zfspv-snapshot
 run_id="deprovision";test_name=$(bash openebs-nativek8s/utils/generate_test_name testcase=zfspv-snapshot metadata=${run_id})
 echo $test_name
-cd litmus
+cd e2e-tests
 
 # copy the content of provisioner run_litmus_test.yml into a different file to update the test specific parameters.
 cp experiments/functional/zfs-LocalPV/zfspv-snapshot/run_litmus_test.yml zfs_snap_deprovision.yml
@@ -177,7 +177,7 @@ app_deprovision() {
 ## Generate test name to run litmusbook for deprovisioning the percona application
 run_id="snap-deprovision";test_name=$(bash openebs-nativek8s/utils/generate_test_name testcase=percona-deployment metadata=${run_id})
 echo $test_name
-cd litmus
+cd e2e-tests
 
 # copy the content of run_litmus_test.yml into a different file to update the test specific parameters.
 cp apps/percona/deployers/run_litmus_test.yml percona_deprovision.yml

--- a/openebs-nativek8s/pipelines/stages/3-functional/ZFSPV-snapshot/ZFSPV-snapshot
+++ b/openebs-nativek8s/pipelines/stages/3-functional/ZFSPV-snapshot/ZFSPV-snapshot
@@ -32,7 +32,7 @@ bash openebs-nativek8s/utils/e2e-cr jobname:s3-j3-zfspv-snapshot jobphase:Runnin
 ## Generate the test name for running the litmusbook for percona deployment
 run_id="zfs-snap";test_name=$(bash openebs-nativek8s/utils/generate_test_name testcase=percona-deployment metadata=${run_id})
 echo $test_name
-cd litmus
+cd e2e-tests
 
 # copy the content of deployers run_litmus_test.yml into a different file to update the test specific parameters.
 cp apps/percona/deployers/run_litmus_test.yml deploy_percona_zfssnap.yml
@@ -75,7 +75,7 @@ app_loadgen() {
 ## Generate test name for running litmusbook for generate load on application
 run_id="zfs-snap";test_name=$(bash openebs-nativek8s/utils/generate_test_name testcase=percona-loadgen metadata=${run_id})
 echo $test_name
-cd litmus
+cd e2e-tests
 
 # copy the content of workload run_litmus_test.yml into a different file to update the test specific parameters.
 cp apps/percona/workload/run_litmus_test.yml loadgen_percona_zfssnap.yml
@@ -116,7 +116,7 @@ zfspv_snapshot() {
 ## Generate test name for running litmusbook for creating zfspv snapshot
 test_name=$(bash openebs-nativek8s/utils/generate_test_name testcase=zfspv-snapshot metadata="")
 echo $test_name
-cd litmus
+cd e2e-tests
 
 # copy the content of run_litmus_test.yml into a different file to update the test specific parameters.
 cp experiments/functional/zfs-LocalPV/zfspv-snapshot/run_litmus_test.yml zfs_snap_test.yml

--- a/openebs-nativek8s/pipelines/stages/4-cleanup/cluster-cleanup/cluster-cleanup
+++ b/openebs-nativek8s/pipelines/stages/4-cleanup/cluster-cleanup/cluster-cleanup
@@ -1,18 +1,18 @@
 #!/bin/bash
 
-pod() {
+connect_cluster() {
 echo $CI_JOB_ID
 ###clone e2e-nativek8s-repo
 echo "cloning e2e-nativek8s repo*************"
 sshpass -p $pass ssh -o StrictHostKeyChecking=no -o LogLevel=ERROR $user@$ip -p $port 'git clone https://github.com/mayadata-io/e2e-nativek8s.git'
-sshpass -p $pass ssh -o StrictHostKeyChecking=no $user@$ip -p $port 'cd e2e-nativek8s && git checkout release-branch && bash openebs-nativek8s/pipelines/stages/4-cleanup/cluster-cleanup/cluster-cleanup node '"'$CI_JOB_ID'"''
+sshpass -p $pass ssh -o StrictHostKeyChecking=no $user@$ip -p $port 'cd e2e-nativek8s && git checkout release-branch && bash openebs-nativek8s/pipelines/stages/4-cleanup/cluster-cleanup/cluster-cleanup run_job '"'$CI_JOB_ID'"''
 }
 
-node() {
+cleanup_cluster() {
 job_id=$(echo $1)
 
-git clone https://github.com/mayadata-io/litmus.git
-cd litmus
+git clone https://github.com/openebs/e2e-tests.git
+cd e2e-tests
 
 # Replace the VM IP In csv file
 sed -i -e 's/10.12.22.10/10.34.1.220/g' \
@@ -36,8 +36,8 @@ ansible-playbook k8s/on-prem/openshift-installer/revert_cluster_state.yml -vv
 cd && rm -rf e2e-nativek8s && rm -rf infra
 }
 
-if [ "$1" == "node" ];then
-  node $2
+if [ "$1" == "run_job" ];then
+  cleanup_cluster $2
 else
-  pod
+  connect_cluster
 fi


### PR DESCRIPTION
- Resolved the pipeline failure issue for zfs-provisioner test where function `pod` was replaced with `connect_cluster`
- changed the `mayadata-io/litmus` repo path to `openebs/e2e-tests`

Signed-off-by: Aman Gupta <aman.gupta@mayadata.io>