### PR TITLE
refacor(script): Resolve the error in no of arguments with function calling

### DIFF
--- a/openebs-nativek8s/pipelines/stages/3-functional/ZFS-LocalPV-provisioner/ZFS-LocalPV-provisioner
+++ b/openebs-nativek8s/pipelines/stages/3-functional/ZFS-LocalPV-provisioner/ZFS-LocalPV-provisioner
@@ -84,7 +84,7 @@ fi
 }
 
 if [ "$1" == "run_job" ];then
-  run_job $2 $3 $4 $5
+  run_job $2 $3 $4 $5 $6
 else
   connect_cluster
 fi


### PR DESCRIPTION
Signed-off-by: Aman Gupta <aman.gupta@mayadata.io>

- No of arguments were one less than it should be.
- Passes the zfs_driver_tag env to the argument for run_job function