### PR TITLE
refactor(Script): Modified the testcase name for the jobs to avoid same name for litmusresult

### DIFF
--- a/openebs-nativek8s/pipelines/stages/3-functional/ZFS-vol-resize-ext4/ZFS-vol-resize-ext4
+++ b/openebs-nativek8s/pipelines/stages/3-functional/ZFS-vol-resize-ext4/ZFS-vol-resize-ext4
@@ -162,7 +162,7 @@ fi
 app_deprovision() {
 
 ## Generate test name for running litmusbook for generate load on application
-run_id="deprovision";test_name=$(bash openebs-nativek8s/utils/generate_test_name testcase=percona-deployment metadata=${run_id})
+run_id="ext4-deprovision";test_name=$(bash openebs-nativek8s/utils/generate_test_name testcase=percona-deployment metadata=${run_id})
 echo $test_name
 
 # copy the content of workload run_litmus_test.yml into a temporary file to update the test specific parameters.

--- a/openebs-nativek8s/pipelines/stages/3-functional/ZFS-vol-resize-xfs/ZFS-vol-resize-xfs
+++ b/openebs-nativek8s/pipelines/stages/3-functional/ZFS-vol-resize-xfs/ZFS-vol-resize-xfs
@@ -162,7 +162,7 @@ fi
 app_deprovision() {
 
 ## Generate test name for running litmusbook for generate load on application
-run_id="deprovision";test_name=$(bash openebs-nativek8s/utils/generate_test_name testcase=percona-deployment metadata=${run_id})
+run_id="xfs-deprovision";test_name=$(bash openebs-nativek8s/utils/generate_test_name testcase=percona-deployment metadata=${run_id})
 echo $test_name
 
 # copy the content of workload run_litmus_test.yml into a temporary file to update the test specific parameters.

--- a/openebs-nativek8s/pipelines/stages/3-functional/ZFS-vol-resize/ZFS-vol-resize
+++ b/openebs-nativek8s/pipelines/stages/3-functional/ZFS-vol-resize/ZFS-vol-resize
@@ -162,7 +162,7 @@ fi
 app_deprovision() {
 
 ## Generate test name for running litmusbook for generate load on application
-run_id="deprovision";test_name=$(bash openebs-nativek8s/utils/generate_test_name testcase=percona-deployment metadata=${run_id})
+run_id="zfs-deprovision";test_name=$(bash openebs-nativek8s/utils/generate_test_name testcase=percona-deployment metadata=${run_id})
 echo $test_name
 
 # copy the content of workload run_litmus_test.yml into a temporary file to update the test specific parameters.


### PR DESCRIPTION

Signed-off-by: Aman Gupta <aman.gupta@mayadata.io>

- Modified the testcase name for the jobs so that no two jobs can conflict with the same name of its litmusresult.