### PR TITLE
refact(script): Printing out the releaseTag in the zfspv-provisioner job

### DIFF
--- a/openebs-nativek8s/pipelines/stages/3-functional/ZFS-LocalPV-provisioner/ZFS-LocalPV-provisioner
+++ b/openebs-nativek8s/pipelines/stages/3-functional/ZFS-LocalPV-provisioner/ZFS-LocalPV-provisioner
@@ -17,6 +17,9 @@ pipeline_id=$(echo $2)
 commit_id=$(echo $3)
 zfs_branch=$(echo $4)
 zfs_driver_image=$(echo $5)
+releaseTag=$(echo $5 | cut -d ":" -f 2)
+echo "releaseTag=$releaseTag"
+
 source ~/.profile
 
 time="date"


### PR DESCRIPTION
- This print value will be used in ci dashboard `openebs.ci`

FIxes: #31 