### PR TITLE
refact(script): Added newly added env values in pipeline script

### DIFF
--- a/openebs-nativek8s/pipelines/stages/3-functional/ZFS-LocalPV-provisioner/ZFS-LocalPV-provisioner
+++ b/openebs-nativek8s/pipelines/stages/3-functional/ZFS-LocalPV-provisioner/ZFS-LocalPV-provisioner
@@ -53,6 +53,8 @@ cp providers/zfs-localpv-provisioner/run_litmus_test.yml zfs_pv_provisioner.yml
 sed -i -e '/name: STORAGE_CLASS/{n;s/.*/            value: zfs-sc/g}' \
 -e "/name: ZFS_BRANCH/{n;s/.*/            value: ${zfs_branch}/g}" \
 -e "/name: ZFS_DRIVER_IMAGE/{n;s/.*/            value: ${zfs_driver_image}/g}" \
+-e '/name: OS_NAME/{n;s/.*/            value: ubuntu/g}' \
+-e '/name: ZPOOL_CREATION/{n;s/.*/            value: "true"/g}' \
 -e '/name: POOL_NAME/{n;s/.*/            value: zfs-test-pool/g}' \
 -e '/name: POOL_TYPE/{n;s/.*/            value: striped/g}' \
 -e '/name: ACTION/{n;s/.*/            value: provision/g}' \


### PR DESCRIPTION
Signed-off-by: Aman Gupta <aman.gupta@mayadata.io>

- Added sed command to take newly added env value which are:
  - OS_NAME: pipeline cluster worker nodes operating system
  - ZPOOL_CREATE: either zpool creation needs to be done `true` or not `false`