### PR TITLE
add(script): add app pod kill and restart test after zfs driver upgrade

### DIFF
--- a/openebs-nativek8s/pipelines/stages/3-app-deploy/app-zv-property-modify
+++ b/openebs-nativek8s/pipelines/stages/3-app-deploy/app-zv-property-modify
@@ -57,6 +57,48 @@ bash openebs-nativek8s/utils/event_updater jobname:app-zv-property-modify $test_
 app_deploy_rc_val=$(echo $?)
 if [ "$app_deploy_rc_val" != "0" ]; then
 exit 1;
+fi
+
+##########################################
+# Load some data in Percona application  #
+##########################################
+
+run_id="zfs-property-modify";test_name=$(bash openebs-nativek8s/utils/generate_test_name testcase=data-persistence-check metadata=${run_id})
+echo $test_name
+
+## copy the content of provisioner run_litmus_test.yml into a temporary file to update the test specific parameters.
+cd e2e-tests
+cp experiments/functional/data-persistence/test.yml zfs_property_modify_data_load.yml
+
+# Modify test specific values in runner file using sed command
+sed -i -e 's/generateName: data-persistence-litmus-/generateName: zfs-property-modify-data-load-/g' \
+-e 's/name: data-persistence/name: zfs-property-modify-data-load/g' \
+-e 's/name: litmus-data-persistence/name: zfs-property-modify-data-load/g' \
+-e '/name: APP_NAMESPACE/{n;s/.*/            value: percona-zfs-modify/}' \
+-e '/name: APP_LABEL/{n;s/.*/            value: '\''name=percona'\''/}' \
+-e '/name: STATUS/{n;s/.*/            value: LOAD/}' \
+-e '/name: DATA_PERSISTENCE/{n;s/.*/            value: mysql/}' zfs_property_modify_data_load.yml
+
+sed -i '/command:/i \
+          - name: RUN_ID\
+            value: '"$run_id"'\
+' zfs_property_modify_data_load.yml
+
+cat zfs_property_modify_data_load.yml
+
+## Run the Litmus job and get the details of the litmus job from litmus_job_runner utils.
+bash ../openebs-nativek8s/utils/litmus_job_runner label='name:zfs-property-modify-data-load' job=zfs_property_modify_data_load.yml
+## Get the cluster state Once the litmus jobs completed.
+bash ../openebs-nativek8s/utils/dump_cluster_state;
+cd ..
+## Update the e2e event for the job.
+bash openebs-nativek8s/utils/event_updater jobname:app-zv-property-modify $test_name jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
+
+rc_val=$(echo $?)
+current_time=$(eval $time)
+
+if [ "$rc_val" != "0" ]; then
+exit 1;
 
 else
 ## Update the e2e-result-custom-resources for the job

--- a/openebs-nativek8s/pipelines/stages/3-app-deploy/app-zv-property-modify-ext4
+++ b/openebs-nativek8s/pipelines/stages/3-app-deploy/app-zv-property-modify-ext4
@@ -57,6 +57,48 @@ bash openebs-nativek8s/utils/event_updater jobname:app-zv-property-modify-ext4 $
 app_deploy_rc_val=$(echo $?)
 if [ "$app_deploy_rc_val" != "0" ]; then
 exit 1;
+fi
+
+##########################################
+# Load some data in Percona application  #
+##########################################
+
+run_id="ext4-property-modify";test_name=$(bash openebs-nativek8s/utils/generate_test_name testcase=data-persistence-check metadata=${run_id})
+echo $test_name
+
+## copy the content of provisioner run_litmus_test.yml into a temporary file to update the test specific parameters.
+cd e2e-tests
+cp experiments/functional/data-persistence/test.yml ext4_property_modify_data_load.yml
+
+# Modify test specific values in runner file using sed command
+sed -i -e 's/generateName: data-persistence-litmus-/generateName: ext4-property-modify-data-load-/g' \
+-e 's/name: data-persistence/name: ext4-property-modify-data-load/g' \
+-e 's/name: litmus-data-persistence/name: ext4-property-modify-data-load/g' \
+-e '/name: APP_NAMESPACE/{n;s/.*/            value: percona-ext4-modify/}' \
+-e '/name: APP_LABEL/{n;s/.*/            value: '\''name=percona'\''/}' \
+-e '/name: STATUS/{n;s/.*/            value: LOAD/}' \
+-e '/name: DATA_PERSISTENCE/{n;s/.*/            value: mysql/}' ext4_property_modify_data_load.yml
+
+sed -i '/command:/i \
+          - name: RUN_ID\
+            value: '"$run_id"'\
+' ext4_property_modify_data_load.yml
+
+cat ext4_property_modify_data_load.yml
+
+## Run the Litmus job and get the details of the litmus job from litmus_job_runner utils.
+bash ../openebs-nativek8s/utils/litmus_job_runner label='name:ext4-property-modify-data-load' job=ext4_property_modify_data_load.yml
+## Get the cluster state Once the litmus jobs completed.
+bash ../openebs-nativek8s/utils/dump_cluster_state;
+cd ..
+## Update the e2e event for the job.
+bash openebs-nativek8s/utils/event_updater jobname:app-zv-property-modify-ext4 $test_name jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
+
+rc_val=$(echo $?)
+current_time=$(eval $time)
+
+if [ "$rc_val" != "0" ]; then
+exit 1;
 
 else
 ## Update the e2e-result-custom-resources for the job

--- a/openebs-nativek8s/pipelines/stages/3-app-deploy/app-zv-property-modify-xfs
+++ b/openebs-nativek8s/pipelines/stages/3-app-deploy/app-zv-property-modify-xfs
@@ -57,6 +57,48 @@ bash openebs-nativek8s/utils/event_updater jobname:app-zv-property-modify-xfs $t
 app_deploy_rc_val=$(echo $?)
 if [ "$app_deploy_rc_val" != "0" ]; then
 exit 1;
+fi
+
+##########################################
+# Load some data in Percona application  #
+##########################################
+
+run_id="xfs-property-modify";test_name=$(bash openebs-nativek8s/utils/generate_test_name testcase=data-persistence-check metadata=${run_id})
+echo $test_name
+
+## copy the content of provisioner run_litmus_test.yml into a temporary file to update the test specific parameters.
+cd e2e-tests
+cp experiments/functional/data-persistence/test.yml xfs_property_modify_data_load.yml
+
+# Modify test specific values in runner file using sed command
+sed -i -e 's/generateName: data-persistence-litmus-/generateName: xfs-property-modify-data-load-/g' \
+-e 's/name: data-persistence/name: xfs-property-modify-data-load/g' \
+-e 's/name: litmus-data-persistence/name: xfs-property-modify-data-load/g' \
+-e '/name: APP_NAMESPACE/{n;s/.*/            value: percona-xfs-modify/}' \
+-e '/name: APP_LABEL/{n;s/.*/            value: '\''name=percona'\''/}' \
+-e '/name: STATUS/{n;s/.*/            value: LOAD/}' \
+-e '/name: DATA_PERSISTENCE/{n;s/.*/            value: mysql/}' xfs_property_modify_data_load.yml
+
+sed -i '/command:/i \
+          - name: RUN_ID\
+            value: '"$run_id"'\
+' xfs_property_modify_data_load.yml
+
+cat xfs_property_modify_data_load.yml
+
+## Run the Litmus job and get the details of the litmus job from litmus_job_runner utils.
+bash ../openebs-nativek8s/utils/litmus_job_runner label='name:xfs-property-modify-data-load' job=xfs_property_modify_data_load.yml
+## Get the cluster state Once the litmus jobs completed.
+bash ../openebs-nativek8s/utils/dump_cluster_state;
+cd ..
+## Update the e2e event for the job.
+bash openebs-nativek8s/utils/event_updater jobname:app-zv-property-modify-xfs $test_name jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
+
+rc_val=$(echo $?)
+current_time=$(eval $time)
+
+if [ "$rc_val" != "0" ]; then
+exit 1;
 
 else
 ## Update the e2e-result-custom-resources for the job

--- a/openebs-nativek8s/pipelines/stages/5-functional/zv-property-modify
+++ b/openebs-nativek8s/pipelines/stages/5-functional/zv-property-modify
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 ## Define and initialize test-result specific variables.
+app_pod_kill_zfs_rc_val=1
 zv_property_modify_rc_val=1
 
 ## SSH into the cluster to run the kubernetes jobs for the experiments
@@ -9,11 +10,7 @@ sshpass -p $pass ssh -o StrictHostKeyChecking=no $user@$ip -p $port -o LogLevel=
 
 }
 
-######################
-# ZV property modify #
-######################
-
-zv_property_modify() {
+app_pod_kill_zfs(){
 
 job_id=$(echo $1)
 pipeline_id=$(echo $2)
@@ -26,6 +23,55 @@ current_time=$(eval $time)
 ## Create the e2e-result-custom-resources for the jobs
 bash openebs-nativek8s/utils/e2e-cr jobname:zv-property-modify jobphase:Waiting
 bash openebs-nativek8s/utils/e2e-cr jobname:zv-property-modify jobphase:Running init_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
+
+run_id="zfs";test_name=$(bash openebs-nativek8s/utils/generate_test_name testcase=application-pod-failure metadata=${run_id})
+echo $test_name
+
+cd e2e-tests
+# copy the content of deployer run_litmus_test.yml into a different file to update the test specific parameters.
+cp experiments/chaos/app_pod_failure/run_litmus_test.yml appkill_zfs.yml
+
+sed -i -e 's/app=jenkins-app/name=percona/g' \
+-e 's/generateName: application-pod-failure-/generateName: application-pod-failure-zfs/g' \
+-e 's/name: application-pod-failure/name: application-pod-failure-zfs/g' \
+-e 's/name: app-failure/name: app-kill-zfs/g' \
+-e 's/value: app-jenkins-ns/value: percona-zfs-modify/g' appkill_zfs.yml
+
+## Replace the value of DATA_PERSISTENCE with application name in litmus experiment. 
+sed -i '/name: DATA_PERSISTENCE/{n;s/.*/            value: mysql/}' appkill_zfs.yml
+
+## Insert the set of variables for busybox data consistency util into configmap spec.
+sed -i '/parameters.yml: |/a \
+    dbuser: root\
+    dbpassword: k8sDem0\
+    dbname: appkillzfs
+' appkill_zfs.yml
+
+sed -i '/command:/i \
+          - name: RUN_ID\
+            value: '"$run_id"'\
+' appkill_zfs.yml
+
+cat appkill_zfs.yml
+
+bash ../openebs-nativek8s/utils/litmus_job_runner label='name:application-pod-failure-zfs' job=appkill_zfs.yml
+cd ..
+# Get the cluster state Once the litmus jobs completed.
+bash openebs-nativek8s/utils/dump_cluster_state;
+bash openebs-nativek8s/utils/event_updater jobname:zv-property-modify $test_name jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
+
+app_pod_kill_zfs_rc_val=$(echo $?)
+if [ "$app_pod_kill_zfs_rc_val" != "0" ]; then
+zv_property_modify
+fi
+
+}
+
+######################
+# ZV property modify #
+######################
+
+zv_property_modify() {
 
 ## Generate the test name for running the litmusbook for percona deployment
 run_id="zfs";test_name=$(bash openebs-nativek8s/utils/generate_test_name testcase=zvol-property-runtime-modify metadata=${run_id})
@@ -110,7 +156,8 @@ bash openebs-nativek8s/utils/event_updater jobname:zv-property-modify $test_name
 app_deprovision_rc_val=$(echo $?)
 
 if [ "$app_deprovision_rc_val" -eq "0" ] &&
-   [ "$zv_property_modify_rc_val" -eq "0" ]; then
+   [ "$zv_property_modify_rc_val" -eq "0" ] &&
+   [ "$app_pod_kill_zfs_rc_val" -eq "0" ]; then
 
 ## Update the e2e-result-custom-resources for the job
 bash openebs-nativek8s/utils/e2e-cr jobname:zv-property-modify jobphase:Completed end_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id" test_result:Pass
@@ -124,7 +171,8 @@ fi
 }
 
 if [ "$1" == "run_job" ];then
-  zv_property_modify $2 $3 $4
+  app_pod_kill_zfs $2 $3 $4
+  zv_property_modify
   app_deprovision
 else
   connect_cluster

--- a/openebs-nativek8s/pipelines/stages/5-functional/zv-property-modify-ext4
+++ b/openebs-nativek8s/pipelines/stages/5-functional/zv-property-modify-ext4
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 ## Define and initialize test-result specific variables.
+app_pod_kill_ext4_rc_val=1
 zv_property_modify_rc_val=1
 
 ## SSH into the cluster to run the kubernetes jobs for the experiments
@@ -9,11 +10,7 @@ sshpass -p $pass ssh -o StrictHostKeyChecking=no $user@$ip -p $port -o LogLevel=
 
 }
 
-######################
-# ZV property modify #
-######################
-
-zv_property_modify() {
+app_pod_kill_ext4(){
 
 job_id=$(echo $1)
 pipeline_id=$(echo $2)
@@ -26,6 +23,54 @@ current_time=$(eval $time)
 ## Create the e2e-result-custom-resources for the jobs
 bash openebs-nativek8s/utils/e2e-cr jobname:zv-property-modify-ext4 jobphase:Waiting
 bash openebs-nativek8s/utils/e2e-cr jobname:zv-property-modify-ext4 jobphase:Running init_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
+
+run_id="ext4";test_name=$(bash openebs-nativek8s/utils/generate_test_name testcase=application-pod-failure metadata=${run_id})
+echo $test_name
+
+cd e2e-tests
+# copy the content of deployer run_litmus_test.yml into a different file to update the test specific parameters.
+cp experiments/chaos/app_pod_failure/run_litmus_test.yml appkill_ext4.yml
+
+sed -i -e 's/app=jenkins-app/name=percona/g' \
+-e 's/generateName: application-pod-failure-/generateName: application-pod-failure-ext4/g' \
+-e 's/name: application-pod-failure/name: application-pod-failure-ext4/g' \
+-e 's/name: app-failure/name: app-kill-ext4/g' \
+-e 's/value: app-jenkins-ns/value: percona-ext4-modify/g' appkill_ext4.yml
+
+## Replace the value of DATA_PERSISTENCE with application name in litmus experiment. 
+sed -i '/name: DATA_PERSISTENCE/{n;s/.*/            value: mysql/}' appkill_ext4.yml
+
+## Insert the set of variables for busybox data consistency util into configmap spec.
+sed -i '/parameters.yml: |/a \
+    dbuser: root\
+    dbpassword: k8sDem0\
+    dbname: appkillext4
+' appkill_ext4.yml
+
+sed -i '/command:/i \
+          - name: RUN_ID\
+            value: '"$run_id"'\
+' appkill_ext4.yml
+
+cat appkill_ext4.yml
+
+bash ../openebs-nativek8s/utils/litmus_job_runner label='name:application-pod-failure-ext4' job=appkill_ext4.yml
+cd ..
+# Get the cluster state Once the litmus jobs completed.
+bash openebs-nativek8s/utils/dump_cluster_state;
+bash openebs-nativek8s/utils/event_updater jobname:zv-property-modify-ext4 $test_name jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
+
+app_pod_kill_ext4_rc_val=$(echo $?)
+if [ "$app_pod_kill_ext4_rc_val" != "0" ]; then
+zv_property_modify
+fi
+
+}
+######################
+# ZV property modify #
+######################
+
+zv_property_modify() {
 
 ## Generate the test name for running the litmusbook for percona deployment
 run_id="ext4";test_name=$(bash openebs-nativek8s/utils/generate_test_name testcase=zvol-property-runtime-modify metadata=${run_id})
@@ -110,7 +155,8 @@ bash openebs-nativek8s/utils/event_updater jobname:zv-property-modify-ext4 $test
 app_deprovision_rc_val=$(echo $?)
 
 if [ "$app_deprovision_rc_val" -eq "0" ] &&
-   [ "$zv_property_modify_rc_val" -eq "0" ]; then
+   [ "$zv_property_modify_rc_val" -eq "0" ] &&
+   [ "$app_pod_kill_ext4_rc_val" -eq "0" ]; then
 
 ## Update the e2e-result-custom-resources for the job
 bash openebs-nativek8s/utils/e2e-cr jobname:zv-property-modify-ext4 jobphase:Completed end_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id" test_result:Pass
@@ -124,7 +170,8 @@ fi
 }
 
 if [ "$1" == "run_job" ];then
-  zv_property_modify $2 $3 $4
+  app_pod_kill_ext4 $2 $3 $4
+  zv_property_modify 
   app_deprovision
 else
   connect_cluster

--- a/openebs-nativek8s/pipelines/stages/5-functional/zv-property-modify-xfs
+++ b/openebs-nativek8s/pipelines/stages/5-functional/zv-property-modify-xfs
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 ## Define and initialize test-result specific variables.
+app_pod_kill_xfs_rc_val=1
 zv_property_modify_rc_val=1
 
 ## SSH into the cluster to run the kubernetes jobs for the experiments
@@ -9,11 +10,7 @@ sshpass -p $pass ssh -o StrictHostKeyChecking=no $user@$ip -p $port -o LogLevel=
 
 }
 
-######################
-# ZV property modify #
-######################
-
-zv_property_modify() {
+app_pod_kill_xfs(){
 
 job_id=$(echo $1)
 pipeline_id=$(echo $2)
@@ -26,6 +23,55 @@ current_time=$(eval $time)
 ## Create the e2e-result-custom-resources for the jobs
 bash openebs-nativek8s/utils/e2e-cr jobname:zv-property-modify-xfs jobphase:Waiting
 bash openebs-nativek8s/utils/e2e-cr jobname:zv-property-modify-xfs jobphase:Running init_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
+
+run_id="xfs";test_name=$(bash openebs-nativek8s/utils/generate_test_name testcase=application-pod-failure metadata=${run_id})
+echo $test_name
+
+cd e2e-tests
+# copy the content of deployer run_litmus_test.yml into a different file to update the test specific parameters.
+cp experiments/chaos/app_pod_failure/run_litmus_test.yml appkill_xfs.yml
+
+sed -i -e 's/app=jenkins-app/name=percona/g' \
+-e 's/generateName: application-pod-failure-/generateName: application-pod-failure-xfs/g' \
+-e 's/name: application-pod-failure/name: application-pod-failure-xfs/g' \
+-e 's/name: app-failure/name: app-kill-xfs/g' \
+-e 's/value: app-jenkins-ns/value: percona-xfs-modify/g' appkill_xfs.yml
+
+## Replace the value of DATA_PERSISTENCE with application name in litmus experiment. 
+sed -i '/name: DATA_PERSISTENCE/{n;s/.*/            value: mysql/}' appkill_xfs.yml
+
+## Insert the set of variables for busybox data consistency util into configmap spec.
+sed -i '/parameters.yml: |/a \
+    dbuser: root\
+    dbpassword: k8sDem0\
+    dbname: appkillxfs
+' appkill_xfs.yml
+
+sed -i '/command:/i \
+          - name: RUN_ID\
+            value: '"$run_id"'\
+' appkill_xfs.yml
+
+cat appkill_xfs.yml
+
+bash ../openebs-nativek8s/utils/litmus_job_runner label='name:application-pod-failure-xfs' job=appkill_xfs.yml
+cd ..
+# Get the cluster state Once the litmus jobs completed.
+bash openebs-nativek8s/utils/dump_cluster_state;
+bash openebs-nativek8s/utils/event_updater jobname:zv-property-modify-xfs $test_name jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
+
+app_pod_kill_xfs_rc_val=$(echo $?)
+if [ "$app_pod_kill_xfs_rc_val" != "0" ]; then
+zv_property_modify
+fi
+
+}
+
+######################
+# ZV property modify #
+######################
+
+zv_property_modify() {
 
 ## Generate the test name for running the litmusbook for percona deployment
 run_id="xfs";test_name=$(bash openebs-nativek8s/utils/generate_test_name testcase=zvol-property-runtime-modify metadata=${run_id})
@@ -110,7 +156,8 @@ bash openebs-nativek8s/utils/event_updater jobname:zv-property-modify-xfs $test_
 app_deprovision_rc_val=$(echo $?)
 
 if [ "$app_deprovision_rc_val" -eq "0" ] &&
-   [ "$zv_property_modify_rc_val" -eq "0" ]; then
+   [ "$zv_property_modify_rc_val" -eq "0" ] &&
+   [ "$app_pod_kill_xfs_rc_val" -eq "0" ]; then
 
 ## Update the e2e-result-custom-resources for the job
 bash openebs-nativek8s/utils/e2e-cr jobname:zv-property-modify-xfs jobphase:Completed end_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id" test_result:Pass
@@ -124,7 +171,8 @@ fi
 }
 
 if [ "$1" == "run_job" ];then
-  zv_property_modify $2 $3 $4
+  app_pod_kill_xfs $2 $3 $4
+  zv_property_modify
   app_deprovision
 else
   connect_cluster


### PR DESCRIPTION
Signed-off-by: Aman Gupta <aman.gupta@mayadata.io>

In upgrade pipeline, after upgrade we are not having any test case where we restart the app_pod or container in application pod of the volume which was provisioned before upgrade. we have this scenario of volumes provisioned after upgrade where we are restarting the pods as a task in checking data-consistency.

This PR adds application pod kill and then restart the application pod test, where after upgrade we will perform this test on application deployed before upgrade.
Fix: https://github.com/openebs/e2e-tests/issues/510