### PR TITLE
refact(script): modify the pipeline script work-flow

### DIFF
--- a/openebs-nativek8s/pipelines/stages/3-functional/3F03-zfs-volume-resize-zfs
+++ b/openebs-nativek8s/pipelines/stages/3-functional/3F03-zfs-volume-resize-zfs
@@ -105,8 +105,7 @@ bash openebs-nativek8s/utils/event_updater jobname:zfs-volume-resize-zfs $test_n
 
 zv_properties_verify_rc_val=$(echo $?)
 if [ "$zv_properties_verify_rc_val" != "0" ]; then
-csi_vol_resize
-app_deprovision
+exit 1;
 fi
 
 }
@@ -151,7 +150,7 @@ bash openebs-nativek8s/utils/event_updater jobname:zfs-volume-resize-zfs $test_n
 
 csi_vol_resize_rc_val=$(echo $?)
 if [ "$csi_vol_resize_rc_val" != "0" ]; then
-app_deprovision
+exit 1;
 fi
 
 }

--- a/openebs-nativek8s/pipelines/stages/3-functional/3F04-zfs-volume-resize-ext4
+++ b/openebs-nativek8s/pipelines/stages/3-functional/3F04-zfs-volume-resize-ext4
@@ -105,8 +105,7 @@ bash openebs-nativek8s/utils/event_updater jobname:zfs-volume-resize-ext4 $test_
 
 zv_properties_verify_rc_val=$(echo $?)
 if [ "$zv_properties_verify_rc_val" != "0" ]; then
-csi_vol_resize
-app_deprovision
+exit 1;
 fi
 
 }
@@ -151,7 +150,7 @@ bash openebs-nativek8s/utils/event_updater jobname:zfs-volume-resize-ext4 $test_
 
 csi_vol_resize_rc_val=$(echo $?)
 if [ "$csi_vol_resize_rc_val" != "0" ]; then
-app_deprovision
+exit 1;
 fi
 
 }

--- a/openebs-nativek8s/pipelines/stages/3-functional/3F05-zfs-volume-resize-xfs
+++ b/openebs-nativek8s/pipelines/stages/3-functional/3F05-zfs-volume-resize-xfs
@@ -105,8 +105,7 @@ bash openebs-nativek8s/utils/event_updater jobname:zfs-volume-resize-xfs $test_n
 
 zv_properties_verify_rc_val=$(echo $?)
 if [ "$zv_properties_verify_rc_val" != "0" ]; then
-csi_vol_resize
-app_deprovision
+exit 1;
 fi
 
 }
@@ -151,7 +150,7 @@ bash openebs-nativek8s/utils/event_updater jobname:zfs-volume-resize-xfs $test_n
 
 csi_vol_resize_rc_val=$(echo $?)
 if [ "$csi_vol_resize_rc_val" != "0" ]; then
-app_deprovision
+exit 1;
 fi
 
 }

--- a/openebs-nativek8s/pipelines/stages/3-functional/3F06-zfspv-property-modify-zfs
+++ b/openebs-nativek8s/pipelines/stages/3-functional/3F06-zfspv-property-modify-zfs
@@ -110,7 +110,7 @@ bash openebs-nativek8s/utils/event_updater jobname:zfspv-property-modify-zfs $te
 
 zv_property_modify_rc_val=$(echo $?)
 if [ "$zv_property_modify_rc_val" != "0" ]; then
-app_deprovision
+exit 1;
 fi
 
 }

--- a/openebs-nativek8s/pipelines/stages/3-functional/3F07-zfspv-property-modify-ext4
+++ b/openebs-nativek8s/pipelines/stages/3-functional/3F07-zfspv-property-modify-ext4
@@ -110,7 +110,7 @@ bash openebs-nativek8s/utils/event_updater jobname:zfspv-property-modify-ext4 $t
 
 zv_property_modify_rc_val=$(echo $?)
 if [ "$zv_property_modify_rc_val" != "0" ]; then
-app_deprovision
+exit 1;
 fi
 
 }

--- a/openebs-nativek8s/pipelines/stages/3-functional/3F08-zfspv-property-modify-xfs
+++ b/openebs-nativek8s/pipelines/stages/3-functional/3F08-zfspv-property-modify-xfs
@@ -110,7 +110,7 @@ bash openebs-nativek8s/utils/event_updater jobname:zfspv-property-modify-xfs $te
 
 zv_property_modify_rc_val=$(echo $?)
 if [ "$zv_property_modify_rc_val" != "0" ]; then
-app_deprovision
+exit 1;
 fi
 
 }

--- a/openebs-nativek8s/pipelines/stages/3-functional/3F09-zfspv-property-modify-btrfs
+++ b/openebs-nativek8s/pipelines/stages/3-functional/3F09-zfspv-property-modify-btrfs
@@ -110,7 +110,7 @@ bash openebs-nativek8s/utils/event_updater jobname:zfspv-property-modify-btrfs $
 
 zv_property_modify_rc_val=$(echo $?)
 if [ "$zv_property_modify_rc_val" != "0" ]; then
-app_deprovision
+exit 1;
 fi
 
 }

--- a/openebs-nativek8s/pipelines/stages/3-functional/3F10-zfspv-snapshot-clone-zfs-create
+++ b/openebs-nativek8s/pipelines/stages/3-functional/3F10-zfspv-snapshot-clone-zfs-create
@@ -106,7 +106,7 @@ bash openebs-nativek8s/utils/event_updater jobname:zfspv-snapshot-clone-zfs-crea
 
 app_loadgen_rc_val=$(echo $?)
 if [ "$app_loadgen_rc_val" != "0" ]; then
-app_deploy
+exit 1;
 fi
 
 }
@@ -152,7 +152,7 @@ bash openebs-nativek8s/utils/event_updater jobname:zfspv-snapshot-clone-zfs-crea
 
 zfspv_snapshot_rc_val=$(echo $?)
 if [ "$zfspv_snapshot_rc_val" != "0" ]; then
-app_deprovision
+exit 1;
 fi
 
 }
@@ -195,8 +195,7 @@ bash openebs-nativek8s/utils/event_updater jobname:zfspv-snapshot-clone-zfs-crea
 zfspv_clone_rc_val=$(echo $?)
 
 if [ "$zfspv_clone_rc_val" != "0" ]; then
-zfspv_snapshot_deprovision
-app_deprovision
+exit 1;
 fi
 
 }
@@ -246,8 +245,7 @@ bash openebs-nativek8s/utils/event_updater jobname:zfspv-snapshot-clone-zfs-crea
 
 zfspv_clone_deprovision_rc_val=$(echo $?)
 if [ "$zfspv_clone_deprovision_rc_val" != "0" ]; then
-zfspv_snapshot_deprovision
-app_deprovision
+exit 1;
 fi
 
 }
@@ -295,7 +293,7 @@ bash openebs-nativek8s/utils/event_updater jobname:zfspv-snapshot-clone-zfs-crea
 
 zfspv_snapshot_deprovision_rc_val=$(echo $?)
 if [ "$zfspv_snapshot_deprovision_rc_val" != "0" ]; then
-app_deprovision
+exit 1;
 fi
 
 }

--- a/openebs-nativek8s/pipelines/stages/3-functional/3F11-zfspv-snapshot-clone-ext4-create
+++ b/openebs-nativek8s/pipelines/stages/3-functional/3F11-zfspv-snapshot-clone-ext4-create
@@ -106,7 +106,7 @@ bash openebs-nativek8s/utils/event_updater jobname:zfspv-snapshot-clone-ext4-cre
 
 app_loadgen_ext4_rc_val=$(echo $?)
 if [ "$app_loadgen_ext4_rc_val" != "0" ]; then
-app_deprovision_ext4
+exit 1;
 fi
 
 }
@@ -160,7 +160,7 @@ bash openebs-nativek8s/utils/event_updater jobname:zfspv-snapshot-clone-ext4-cre
 
 zfspv_snapshot_ext4_rc_val=$(echo $?)
 if [ "$zfspv_snapshot_ext4_rc_val" != "0" ]; then
-app_deprovision_ext4
+exit 1;
 fi
 
 }
@@ -210,8 +210,7 @@ bash openebs-nativek8s/utils/event_updater jobname:zfspv-snapshot-clone-ext4-cre
 
 zfspv_clone_ext4_rc_val=$(echo $?)
 if [ "$zfspv_clone_ext4_rc_val" != "0" ]; then
-zfspv_snapshot_deprovision_ext4
-app_deprovision_ext4
+exit 1;
 fi
 
 }
@@ -262,8 +261,7 @@ bash openebs-nativek8s/utils/event_updater jobname:zfspv-snapshot-clone-ext4-cre
 
 zfspv_clone_ext4_deprovision_rc_val=$(echo $?)
 if [ "$zfspv_clone_ext4_deprovision_rc_val" != "0" ]; then
-zfspv_snapshot_deprovision_ext4
-app_deprovision_ext4
+exit 1;
 fi
 
 }
@@ -312,7 +310,7 @@ bash openebs-nativek8s/utils/event_updater jobname:zfspv-snapshot-clone-ext4-cre
 
 zfspv_snapshot_ext4_deprovision_rc_val=$(echo $?)
 if [ "$zfspv_snapshot_ext4_deprovision_rc_val" != "0" ]; then
-app_deprovision_ext4
+exit 1;
 fi
 
 }

--- a/openebs-nativek8s/pipelines/stages/3-functional/3F12-zfspv-snapshot-clone-xfs-create
+++ b/openebs-nativek8s/pipelines/stages/3-functional/3F12-zfspv-snapshot-clone-xfs-create
@@ -106,7 +106,7 @@ bash openebs-nativek8s/utils/event_updater jobname:zfspv-snapshot-clone-xfs-crea
 
 app_loadgen_xfs_rc_val=$(echo $?)
 if [ "$app_loadgen_xfs_rc_val" != "0" ]; then
-app_deprovision_xfs
+exit 1;
 fi
 
 }
@@ -160,7 +160,7 @@ bash openebs-nativek8s/utils/event_updater jobname:zfspv-snapshot-clone-xfs-crea
 
 zfspv_snapshot_xfs_rc_val=$(echo $?)
 if [ "$zfspv_snapshot_xfs_rc_val" != "0" ]; then
-app_deprovision_xfs
+exit 1;
 fi
 
 }
@@ -210,8 +210,7 @@ bash openebs-nativek8s/utils/event_updater jobname:zfspv-snapshot-clone-xfs-crea
 
 zfspv_clone_xfs_rc_val=$(echo $?)
 if [ "$zfspv_clone_xfs_rc_val" != "0" ]; then
-zfspv_snapshot_deprovision_xfs
-app_deprovision_xfs
+exit 1;
 fi
 
 }
@@ -262,8 +261,7 @@ bash openebs-nativek8s/utils/event_updater jobname:zfspv-snapshot-clone-xfs-crea
 
 zfspv_clone_xfs_deprovision_rc_val=$(echo $?)
 if [ "$zfspv_clone_xfs_deprovision_rc_val" != "0" ]; then
-zfspv_snapshot_deprovision_xfs
-app_deprovision_xfs
+exit 1;
 fi
 
 }
@@ -312,7 +310,7 @@ bash openebs-nativek8s/utils/event_updater jobname:zfspv-snapshot-clone-xfs-crea
 
 zfspv_snapshot_xfs_deprovision_rc_val=$(echo $?)
 if [ "$zfspv_snapshot_xfs_deprovision_rc_val" != "0" ]; then
-app_deprovision_xfs
+exit 1;
 fi
 
 }

--- a/openebs-nativek8s/pipelines/stages/3-functional/3F13-zfspv-snapshot-clone-btrfs-create
+++ b/openebs-nativek8s/pipelines/stages/3-functional/3F13-zfspv-snapshot-clone-btrfs-create
@@ -106,7 +106,7 @@ bash openebs-nativek8s/utils/event_updater jobname:zfspv-snapshot-clone-btrfs-cr
 
 app_loadgen_btrfs_rc_val=$(echo $?)
 if [ "$app_loadgen_btrfs_rc_val" != "0" ]; then
-app_deprovision_btrfs
+exit 1;
 fi
 
 }
@@ -160,7 +160,7 @@ bash openebs-nativek8s/utils/event_updater jobname:zfspv-snapshot-clone-btrfs-cr
 
 zfspv_snapshot_btrfs_rc_val=$(echo $?)
 if [ "$zfspv_snapshot_btrfs_rc_val" != "0" ]; then
-app_deprovision_btrfs
+exit 1;
 fi
 
 }
@@ -210,8 +210,7 @@ bash openebs-nativek8s/utils/event_updater jobname:zfspv-snapshot-clone-btrfs-cr
 
 zfspv_clone_btrfs_rc_val=$(echo $?)
 if [ "$zfspv_clone_btrfs_rc_val" != "0" ]; then
-zfspv_snapshot_deprovision_btrfs
-app_deprovision_btrfs
+exit 1;
 fi
 
 }
@@ -262,8 +261,7 @@ bash openebs-nativek8s/utils/event_updater jobname:zfspv-snapshot-clone-btrfs-cr
 
 zfspv_clone_btrfs_deprovision_rc_val=$(echo $?)
 if [ "$zfspv_clone_btrfs_deprovision_rc_val" != "0" ]; then
-zfspv_snapshot_deprovision_btrfs
-app_deprovision_btrfs
+exit 1;
 fi
 
 }
@@ -312,7 +310,7 @@ bash openebs-nativek8s/utils/event_updater jobname:zfspv-snapshot-clone-btrfs-cr
 
 zfspv_snapshot_btrfs_deprovision_rc_val=$(echo $?)
 if [ "$zfspv_snapshot_btrfs_deprovision_rc_val" != "0" ]; then
-app_deprovision_btrfs
+exit 1;
 fi
 
 }

--- a/openebs-nativek8s/pipelines/stages/3-functional/3F14-zfspv-shared-mount-volume-zfs
+++ b/openebs-nativek8s/pipelines/stages/3-functional/3F14-zfspv-shared-mount-volume-zfs
@@ -121,7 +121,7 @@ bash openebs-nativek8s/utils/event_updater jobname:zfspv-shared-mount-volume-zfs
 
 zfspv_shared_mount_snapshot_zfs_rc_val=$(echo $?)
 if [ "$zfspv_shared_mount_snapshot_zfs_rc_val" != "0" ]; then
-zfspv_shared_mount_zfs_deprovision
+exit 1;
 fi
 
 }
@@ -170,8 +170,7 @@ bash openebs-nativek8s/utils/event_updater jobname:zfspv-shared-mount-volume-zfs
 
 zfspv_shared_mount_clone_zfs_rc_val=$(echo $?)
 if [ "$zfspv_shared_mount_clone_zfs_rc_val" != "0" ]; then
-zfspv_shared_mount_snapshot_zfs_deprovision
-zfspv_shared_mount_zfs_deprovision
+exit 1;
 fi
 
 }
@@ -221,8 +220,7 @@ bash openebs-nativek8s/utils/event_updater jobname:zfspv-shared-mount-volume-zfs
 
 zfspv_shared_mount_clone_zfs_deprovision_rc_val=$(echo $?)
 if [ "$zfspv_shared_mount_clone_zfs_deprovision_rc_val" != "0" ]; then
-zfspv_shared_mount_snapshot_zfs_deprovision
-zfspv_shared_mount_zfs_deprovision
+exit 1;
 fi
 
 }
@@ -270,7 +268,7 @@ bash openebs-nativek8s/utils/event_updater jobname:zfspv-shared-mount-volume-zfs
 
 zfspv_shared_mount_snapshot_zfs_deprovision_rc_val=$(echo $?)
 if [ "$zfspv_shared_mount_snapshot_zfs_deprovision_rc_val" != "0" ]; then
-zfspv_shared_mount_zfs_deprovision
+exit 1;
 fi
 
 }

--- a/openebs-nativek8s/pipelines/stages/3-functional/3F15-zfspv-shared-mount-volume-ext4
+++ b/openebs-nativek8s/pipelines/stages/3-functional/3F15-zfspv-shared-mount-volume-ext4
@@ -121,7 +121,7 @@ bash openebs-nativek8s/utils/event_updater jobname:zfspv-shared-mount-volume-ext
 
 zfspv_shared_mount_snapshot_ext4_rc_val=$(echo $?)
 if [ "$zfspv_shared_mount_snapshot_ext4_rc_val" != "0" ]; then
-zfspv_shared_mount_ext4_deprovision
+exit 1;
 fi
 
 }
@@ -170,8 +170,7 @@ bash openebs-nativek8s/utils/event_updater jobname:zfspv-shared-mount-volume-ext
 
 zfspv_shared_mount_clone_ext4_rc_val=$(echo $?)
 if [ "$zfspv_shared_mount_clone_ext4_rc_val" != "0" ]; then
-zfspv_shared_mount_snapshot_ext4_deprovision
-zfspv_shared_mount_ext4_deprovision
+exit 1;
 fi
 
 }
@@ -221,8 +220,7 @@ bash openebs-nativek8s/utils/event_updater jobname:zfspv-shared-mount-volume-ext
 
 zfspv_shared_mount_clone_ext4_deprovision_rc_val=$(echo $?)
 if [ "$zfspv_shared_mount_clone_ext4_deprovision_rc_val" != "0" ]; then
-zfspv_shared_mount_snapshot_ext4_deprovision
-zfspv_shared_mount_ext4_deprovision
+exit 1;
 fi
 
 }
@@ -270,7 +268,7 @@ bash openebs-nativek8s/utils/event_updater jobname:zfspv-shared-mount-volume-ext
 
 zfspv_shared_mount_snapshot_ext4_deprovision_rc_val=$(echo $?)
 if [ "$zfspv_shared_mount_snapshot_ext4_deprovision_rc_val" != "0" ]; then
-zfspv_shared_mount_ext4_deprovision
+exit 1;
 fi
 
 }

--- a/openebs-nativek8s/pipelines/stages/3-functional/3F16-zfspv-shared-mount-volume-xfs
+++ b/openebs-nativek8s/pipelines/stages/3-functional/3F16-zfspv-shared-mount-volume-xfs
@@ -121,7 +121,7 @@ bash openebs-nativek8s/utils/event_updater jobname:zfspv-shared-mount-volume-xfs
 
 zfspv_shared_mount_snapshot_xfs_rc_val=$(echo $?)
 if [ "$zfspv_shared_mount_snapshot_xfs_rc_val" != "0" ]; then
-zfspv_shared_mount_xfs_deprovision
+exit 1;
 fi
 
 }
@@ -170,8 +170,7 @@ bash openebs-nativek8s/utils/event_updater jobname:zfspv-shared-mount-volume-xfs
 
 zfspv_shared_mount_clone_xfs_rc_val=$(echo $?)
 if [ "$zfspv_shared_mount_clone_xfs_rc_val" != "0" ]; then
-zfspv_shared_mount_snapshot_xfs_deprovision
-zfspv_shared_mount_xfs_deprovision
+exit 1;
 fi
 
 }
@@ -221,8 +220,7 @@ bash openebs-nativek8s/utils/event_updater jobname:zfspv-shared-mount-volume-xfs
 
 zfspv_shared_mount_clone_xfs_deprovision_rc_val=$(echo $?)
 if [ "$zfspv_shared_mount_clone_xfs_deprovision_rc_val" != "0" ]; then
-zfspv_shared_mount_snapshot_xfs_deprovision
-zfspv_shared_mount_xfs_deprovision
+exit 1;
 fi
 
 }
@@ -270,7 +268,7 @@ bash openebs-nativek8s/utils/event_updater jobname:zfspv-shared-mount-volume-xfs
 
 zfspv_shared_mount_snapshot_xfs_deprovision_rc_val=$(echo $?)
 if [ "$zfspv_shared_mount_snapshot_xfs_deprovision_rc_val" != "0" ]; then
-zfspv_shared_mount_xfs_deprovision
+exit 1;
 fi
 
 }

--- a/openebs-nativek8s/pipelines/stages/3-functional/3F17-zfspv-shared-mount-volume-btrfs
+++ b/openebs-nativek8s/pipelines/stages/3-functional/3F17-zfspv-shared-mount-volume-btrfs
@@ -121,7 +121,7 @@ bash openebs-nativek8s/utils/event_updater jobname:zfspv-shared-mount-volume-btr
 
 zfspv_shared_mount_snapshot_btrfs_rc_val=$(echo $?)
 if [ "$zfspv_shared_mount_snapshot_btrfs_rc_val" != "0" ]; then
-zfspv_shared_mount_btrfs_deprovision
+exit 1;
 fi
 
 }
@@ -170,8 +170,7 @@ bash openebs-nativek8s/utils/event_updater jobname:zfspv-shared-mount-volume-btr
 
 zfspv_shared_mount_clone_btrfs_rc_val=$(echo $?)
 if [ "$zfspv_shared_mount_clone_btrfs_rc_val" != "0" ]; then
-zfspv_shared_mount_snapshot_btrfs_deprovision
-zfspv_shared_mount_btrfs_deprovision
+exit 1;
 fi
 
 }
@@ -221,8 +220,7 @@ bash openebs-nativek8s/utils/event_updater jobname:zfspv-shared-mount-volume-btr
 
 zfspv_shared_mount_clone_btrfs_deprovision_rc_val=$(echo $?)
 if [ "$zfspv_shared_mount_clone_btrfs_deprovision_rc_val" != "0" ]; then
-zfspv_shared_mount_snapshot_btrfs_deprovision
-zfspv_shared_mount_btrfs_deprovision
+exit 1;
 fi
 
 }
@@ -270,7 +268,7 @@ bash openebs-nativek8s/utils/event_updater jobname:zfspv-shared-mount-volume-btr
 
 zfspv_shared_mount_snapshot_btrfs_deprovision_rc_val=$(echo $?)
 if [ "$zfspv_shared_mount_snapshot_btrfs_deprovision_rc_val" != "0" ]; then
-zfspv_shared_mount_btrfs_deprovision
+exit 1;
 fi
 
 }

--- a/openebs-nativek8s/pipelines/stages/3-functional/3F24-zfspv-clone-from-pvc-zfs
+++ b/openebs-nativek8s/pipelines/stages/3-functional/3F24-zfspv-clone-from-pvc-zfs
@@ -103,7 +103,7 @@ bash openebs-nativek8s/utils/event_updater jobname:zfspv-clone-from-pvc-zfs $tes
 
 app_loadgen_rc_val=$(echo $?)
 if [ "$app_loadgen_rc_val" != "0" ]; then
-app_deprovision
+exit 1;
 fi
 
 }
@@ -160,7 +160,7 @@ bash openebs-nativek8s/utils/event_updater jobname:zfspv-clone-from-pvc-zfs $tes
 
 clone_from_pvc_zfs_rc_val=$(echo $?)
 if [ "$clone_from_pvc_zfs_rc_val" != "0" ]; then
-app_deprovision
+exit 1;
 fi
 
 }

--- a/openebs-nativek8s/pipelines/stages/3-functional/3F25-zfspv-clone-from-pvc-ext4
+++ b/openebs-nativek8s/pipelines/stages/3-functional/3F25-zfspv-clone-from-pvc-ext4
@@ -103,7 +103,7 @@ bash openebs-nativek8s/utils/event_updater jobname:zfspv-clone-from-pvc-ext4 $te
 
 app_loadgen_rc_val=$(echo $?)
 if [ "$app_loadgen_rc_val" != "0" ]; then
-app_deprovision
+exit 1;
 fi
 
 }
@@ -160,7 +160,7 @@ bash openebs-nativek8s/utils/event_updater jobname:zfspv-clone-from-pvc-ext4 $te
 
 clone_from_pvc_ext4_rc_val=$(echo $?)
 if [ "$clone_from_pvc_ext4_rc_val" != "0" ]; then
-app_deprovision
+exit 1;
 fi
 
 }

--- a/openebs-nativek8s/pipelines/stages/3-functional/3F26-zfspv-clone-from-pvc-xfs
+++ b/openebs-nativek8s/pipelines/stages/3-functional/3F26-zfspv-clone-from-pvc-xfs
@@ -103,7 +103,7 @@ bash openebs-nativek8s/utils/event_updater jobname:zfspv-clone-from-pvc-xfs $tes
 
 app_loadgen_rc_val=$(echo $?)
 if [ "$app_loadgen_rc_val" != "0" ]; then
-app_deprovision
+exit 1;
 fi
 
 }
@@ -160,7 +160,7 @@ bash openebs-nativek8s/utils/event_updater jobname:zfspv-clone-from-pvc-xfs $tes
 
 clone_from_pvc_xfs_rc_val=$(echo $?)
 if [ "$clone_from_pvc_xfs_rc_val" != "0" ]; then
-app_deprovision
+exit 1;
 fi
 
 }

--- a/openebs-nativek8s/pipelines/stages/4-chaos/4C01-app-pod-kill-zfs
+++ b/openebs-nativek8s/pipelines/stages/4-chaos/4C01-app-pod-kill-zfs
@@ -103,7 +103,7 @@ bash openebs-nativek8s/utils/event_updater jobname:app-pod-kill-zfs $test_name j
 
 app_loadgen_rc_val=$(echo $?)
 if [ "$app_loadgen_rc_val" != "0" ]; then
-app_deprovision
+exit 1;
 fi
 
 }
@@ -152,7 +152,7 @@ bash openebs-nativek8s/utils/event_updater jobname:app-pod-kill-zfs $test_name j
 
 app_pod_kill_zfs_rc_val=$(echo $?)
 if [ "$app_pod_kill_zfs_rc_val" != "0" ]; then
-app_deprovision
+exit 1;
 fi
 
 }

--- a/openebs-nativek8s/pipelines/stages/4-chaos/4C02-app-pod-kill-xfs
+++ b/openebs-nativek8s/pipelines/stages/4-chaos/4C02-app-pod-kill-xfs
@@ -103,7 +103,7 @@ bash openebs-nativek8s/utils/event_updater jobname:app-pod-kill-xfs $test_name j
 
 app_loadgen_rc_val=$(echo $?)
 if [ "$app_loadgen_rc_val" != "0" ]; then
-app_deprovision
+exit 1;
 fi
 
 }
@@ -152,7 +152,7 @@ bash openebs-nativek8s/utils/event_updater jobname:app-pod-kill-xfs $test_name j
 
 app_pod_kill_xfs_rc_val=$(echo $?)
 if [ "$app_pod_kill_xfs_rc_val" != "0" ]; then
-app_deprovision
+exit 1;
 fi
 
 }

--- a/openebs-nativek8s/pipelines/stages/4-chaos/4C03-app-pod-kill-ext4
+++ b/openebs-nativek8s/pipelines/stages/4-chaos/4C03-app-pod-kill-ext4
@@ -103,7 +103,7 @@ bash openebs-nativek8s/utils/event_updater jobname:app-pod-kill-ext4 $test_name 
 
 app_loadgen_rc_val=$(echo $?)
 if [ "$app_loadgen_rc_val" != "0" ]; then
-app_deprovision
+exit 1;
 fi
 
 }
@@ -152,7 +152,7 @@ bash openebs-nativek8s/utils/event_updater jobname:app-pod-kill-ext4 $test_name 
 
 app_pod_kill_ext4_rc_val=$(echo $?)
 if [ "$app_pod_kill_ext4_rc_val" != "0" ]; then
-app_deprovision
+exit 1;
 fi
 
 }

--- a/openebs-nativek8s/pipelines/stages/4-chaos/4C04-app-pod-kill-btrfs
+++ b/openebs-nativek8s/pipelines/stages/4-chaos/4C04-app-pod-kill-btrfs
@@ -103,7 +103,7 @@ bash openebs-nativek8s/utils/event_updater jobname:app-pod-kill-btrfs $test_name
 
 app_loadgen_rc_val=$(echo $?)
 if [ "$app_loadgen_rc_val" != "0" ]; then
-app_deprovision
+exit 1;
 fi
 
 }
@@ -152,7 +152,7 @@ bash openebs-nativek8s/utils/event_updater jobname:app-pod-kill-btrfs $test_name
 
 app_pod_kill_btrfs_rc_val=$(echo $?)
 if [ "$app_pod_kill_btrfs_rc_val" != "0" ]; then
-app_deprovision
+exit 1;
 fi
 
 }

--- a/openebs-nativek8s/pipelines/stages/5-infra-chaos/5I01-node-docker-restart-zfs
+++ b/openebs-nativek8s/pipelines/stages/5-infra-chaos/5I01-node-docker-restart-zfs
@@ -111,7 +111,7 @@ bash openebs-nativek8s/utils/event_updater jobname:node-docker-restart-zfs $test
 
 app_loadgen_rc_val=$(echo $?)
 if [ "$app_loadgen_rc_val" != "0" ]; then
-app_deprovision
+exit 1;
 fi
 
 }
@@ -168,7 +168,7 @@ bash openebs-nativek8s/utils/event_updater jobname:node-docker-restart-zfs $test
 
 zfs_docker_restart_rc_val=$(echo $?)
 if [ "$zfs_docker_restart_rc_val" != "0" ]; then
-app_deprovision
+exit 1;
 fi
 
 }

--- a/openebs-nativek8s/pipelines/stages/5-infra-chaos/5I02-node-kubelet-restart-zfs
+++ b/openebs-nativek8s/pipelines/stages/5-infra-chaos/5I02-node-kubelet-restart-zfs
@@ -107,7 +107,7 @@ bash openebs-nativek8s/utils/event_updater jobname:node-kubelet-restart-zfs $tes
 
 app_loadgen_rc_val=$(echo $?)
 if [ "$app_loadgen_rc_val" != "0" ]; then
-app_deprovision
+exit 1;
 fi
 
 }
@@ -164,7 +164,7 @@ bash openebs-nativek8s/utils/event_updater jobname:node-kubelet-restart-zfs $tes
 
 zfs_kubelet_restart_rc_val=$(echo $?)
 if [ "$zfs_kubelet_restart_rc_val" != "0" ]; then
-app_deprovision
+exit 1;
 fi
 
 }

--- a/openebs-nativek8s/pipelines/stages/5-infra-chaos/5I03-node-failure-zfs
+++ b/openebs-nativek8s/pipelines/stages/5-infra-chaos/5I03-node-failure-zfs
@@ -107,7 +107,7 @@ bash openebs-nativek8s/utils/event_updater jobname:node-failure-zfs $test_name j
 
 app_loadgen_rc_val=$(echo $?)
 if [ "$app_loadgen_rc_val" != "0" ]; then
-app_deprovision
+exit 1;
 fi
 
 }
@@ -166,7 +166,7 @@ bash openebs-nativek8s/utils/event_updater jobname:node-failure-zfs $test_name j
 
 node_failure_zfs_rc_val=$(echo $?)
 if [ "$node_failure_zfs_rc_val" != "0" ]; then
-app_deprovision
+exit 1;
 fi
 
 }


### PR DESCRIPTION
Signed-off-by: w3aman <aman.gupta@mayadata.io>
- As of now, in pipeline script work-flow is in the way where if any task fails, we exit the test-case by doing necessary deprovision to avoid any stale resources in ongoing pipeline cluster.

But this approach makes it tedious to debug the failures as application deprovision is done, so no application is present in the cluster.
- To overcome this, we exit after the failed test case directly without any deprovisioning. 