### PR TITLE
refact(script): make backup-restore test-cases execution parallel in pipeline

### DIFF
--- a/openebs-nativek8s/pipelines/stages/3-functional/3F20-xfs-backup-restore-diff-ns
+++ b/openebs-nativek8s/pipelines/stages/3-functional/3F20-xfs-backup-restore-diff-ns
@@ -29,7 +29,7 @@ time="date"
 current_time=$(eval $time)
 
 ## Pooling over the previous job to wait for its completion
-bash openebs-nativek8s/utils/pooling jobname:ext4-backup-restore-diff-ns
+bash openebs-nativek8s/utils/pooling jobname:zfs-backup-restore-diff-ns
 bash openebs-nativek8s/utils/e2e-cr jobname:xfs-backup-restore-diff-ns jobphase:Running init_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
 
 ## Generate the test name for running the litmusbook for percona deployment

--- a/openebs-nativek8s/pipelines/stages/3-functional/3F21-zfs-backup-restore-same-ns
+++ b/openebs-nativek8s/pipelines/stages/3-functional/3F21-zfs-backup-restore-same-ns
@@ -29,7 +29,7 @@ time="date"
 current_time=$(eval $time)
 
 ## Pooling over the previous job to wait for its completion
-bash openebs-nativek8s/utils/pooling jobname:xfs-backup-restore-diff-ns
+bash openebs-nativek8s/utils/pooling jobname:zfs-backup-restore-diff-ns
 bash openebs-nativek8s/utils/e2e-cr jobname:zfs-backup-restore-same-ns jobphase:Running init_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
 
 ## Generate the test name for running the litmusbook for percona deployment

--- a/openebs-nativek8s/pipelines/stages/3-functional/3F22-ext4-backup-restore-same-ns
+++ b/openebs-nativek8s/pipelines/stages/3-functional/3F22-ext4-backup-restore-same-ns
@@ -29,7 +29,7 @@ time="date"
 current_time=$(eval $time)
 
 ## Pooling over the previous job to wait for its completion
-bash openebs-nativek8s/utils/pooling jobname:zfs-backup-restore-same-ns
+bash openebs-nativek8s/utils/pooling jobname:zfs-backup-restore-diff-ns
 bash openebs-nativek8s/utils/e2e-cr jobname:ext4-backup-restore-same-ns jobphase:Running init_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
 
 ## Generate the test name for running the litmusbook for percona deployment

--- a/openebs-nativek8s/pipelines/stages/3-functional/3F23-xfs-backup-restore-same-ns
+++ b/openebs-nativek8s/pipelines/stages/3-functional/3F23-xfs-backup-restore-same-ns
@@ -29,7 +29,7 @@ time="date"
 current_time=$(eval $time)
 
 ## Pooling over the previous job to wait for its completion
-bash openebs-nativek8s/utils/pooling jobname:ext4-backup-restore-same-ns
+bash openebs-nativek8s/utils/pooling jobname:zfs-backup-restore-diff-ns
 bash openebs-nativek8s/utils/e2e-cr jobname:xfs-backup-restore-same-ns jobphase:Running init_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
 
 ## Generate the test name for running the litmusbook for percona deployment

--- a/openebs-nativek8s/pipelines/stages/3-functional/3F27-zfs-backup-restore-diff-node
+++ b/openebs-nativek8s/pipelines/stages/3-functional/3F27-zfs-backup-restore-diff-node
@@ -29,7 +29,7 @@ time="date"
 current_time=$(eval $time)
 
 ## Pooling over the previous job to wait for its completion
-bash openebs-nativek8s/utils/pooling jobname:xfs-backup-restore-same-ns
+bash openebs-nativek8s/utils/pooling jobname:zfs-backup-restore-diff-ns
 bash openebs-nativek8s/utils/e2e-cr jobname:zfs-backup-restore-diff-node jobphase:Running init_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
 
 ## Generate the test name for running the litmusbook for percona deployment

--- a/openebs-nativek8s/pipelines/stages/3-functional/3F28-ext4-backup-restore-diff-node
+++ b/openebs-nativek8s/pipelines/stages/3-functional/3F28-ext4-backup-restore-diff-node
@@ -29,7 +29,7 @@ time="date"
 current_time=$(eval $time)
 
 ## Pooling over the previous job to wait for its completion
-bash openebs-nativek8s/utils/pooling jobname:zfs-backup-restore-diff-node
+bash openebs-nativek8s/utils/pooling jobname:zfs-backup-restore-diff-ns
 bash openebs-nativek8s/utils/e2e-cr jobname:ext4-backup-restore-diff-node jobphase:Running init_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
 
 ## Generate the test name for running the litmusbook for percona deployment

--- a/openebs-nativek8s/pipelines/stages/3-functional/3F29-xfs-backup-restore-diff-node
+++ b/openebs-nativek8s/pipelines/stages/3-functional/3F29-xfs-backup-restore-diff-node
@@ -29,7 +29,7 @@ time="date"
 current_time=$(eval $time)
 
 ## Pooling over the previous job to wait for its completion
-bash openebs-nativek8s/utils/pooling jobname:ext4-backup-restore-diff-node
+bash openebs-nativek8s/utils/pooling jobname:zfs-backup-restore-diff-ns
 bash openebs-nativek8s/utils/e2e-cr jobname:xfs-backup-restore-diff-node jobphase:Running init_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
 
 ## Generate the test name for running the litmusbook for percona deployment

--- a/openebs-nativek8s/pipelines/stages/3-functional/3F30-zfs-incremental-backup-restore
+++ b/openebs-nativek8s/pipelines/stages/3-functional/3F30-zfs-incremental-backup-restore
@@ -29,7 +29,7 @@ time="date"
 current_time=$(eval $time)
 
 ## Pooling over the previous job to wait for its completion
-bash openebs-nativek8s/utils/pooling jobname:xfs-backup-restore-diff-node
+bash openebs-nativek8s/utils/pooling jobname:zfs-backup-restore-diff-ns
 bash openebs-nativek8s/utils/e2e-cr jobname:zfs-incr-backup-restore jobphase:Running init_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
 
 ## Generate the test name for running the litmusbook for percona deployment


### PR DESCRIPTION

Signed-off-by: w3aman <aman.gupta@mayadata.io>

- To decrease the execution time of backup restore test cases in pipeline, making test-cases execution order parallel instead of sequential where we were waiting for the previous job to complete before running the next job.