### PR TITLE
refact(script): dump the k8s version of pipeline cluster

### DIFF
--- a/pipeline/stages/1-cluster-setup/1S01-cluster-setup
+++ b/pipeline/stages/1-cluster-setup/1S01-cluster-setup
@@ -13,6 +13,9 @@ chmod 600 /root/.ssh/id_rsa
 state="ssh -o StrictHostKeyChecking=no $zfs_user@$zfs_ip -p $zfs_port -i /root/.ssh/id_rsa -o LogLevel=ERROR 'ls | grep e2e-nativek8s'"
 cluster_state=$(eval $state)
 
+kubectl_version=$(ssh -o StrictHostKeyChecking=no $zfs_user@$zfs_ip -p $zfs_port -i /root/.ssh/id_rsa kubectl get nodes --no-headers -o custom-columns=:.status.nodeInfo.kubeletVersion | uniq | cut -d '+' -f 1)
+echo "k8s_version==$kubectl_version"
+
 while [ "${cluster_state}" == "e2e-nativek8s" ]; do
   echo "***cluster is Engaged******"
   wait=1

--- a/pipeline/stages/5-infra-chaos/5I01-node-docker-restart-zfs
+++ b/pipeline/stages/5-infra-chaos/5I01-node-docker-restart-zfs
@@ -1,10 +1,5 @@
 #!/bin/bash
 
-### Taint the node to run infra chaos test scripts
-node_name=$(ssh -o StrictHostKeyChecking=no $zfs_user@$zfs_ip -p $zfs_port -i /root/.ssh/id_rsa -o LogLevel=ERROR kubectl get nodes --no-headers | grep -v master | awk 'FNR==1 {print $1}')
-ssh -o StrictHostKeyChecking=no $zfs_user@$zfs_ip -p $zfs_port -i /root/.ssh/id_rsa -o LogLevel=ERROR "kubectl taint nodes $node_name infra-aid=observer:NoSchedule"
-ssh -o StrictHostKeyChecking=no $zfs_user@$zfs_ip -p $zfs_port -i /root/.ssh/id_rsa -o LogLevel=ERROR "mkdir infra && echo $node_name >> infra/node_name"
-
 ## Define and initialize test-result specific variables.
 app_deploy_rc_val=1
 app_loadgen_rc_val=1
@@ -16,6 +11,12 @@ mkdir -p /root/.ssh
 touch /root/.ssh/id_rsa
 echo "$SSH_KEYS" > /root/.ssh/id_rsa
 chmod 600 /root/.ssh/id_rsa
+
+### Taint the node to run infra chaos test scripts
+node_name=$(ssh -o StrictHostKeyChecking=no $zfs_user@$zfs_ip -p $zfs_port -i /root/.ssh/id_rsa -o LogLevel=ERROR kubectl get nodes --no-headers | grep -v master | awk 'FNR==1 {print $1}')
+ssh -o StrictHostKeyChecking=no $zfs_user@$zfs_ip -p $zfs_port -i /root/.ssh/id_rsa -o LogLevel=ERROR "kubectl taint nodes $node_name infra-aid=observer:NoSchedule"
+ssh -o StrictHostKeyChecking=no $zfs_user@$zfs_ip -p $zfs_port -i /root/.ssh/id_rsa -o LogLevel=ERROR "mkdir infra && echo $node_name >> infra/node_name"
+
 ssh -o StrictHostKeyChecking=no $zfs_user@$zfs_ip -p $zfs_port -i /root/.ssh/id_rsa -o LogLevel=ERROR 'cd e2e-nativek8s && bash pipeline/stages/5-infra-chaos/5I01-node-docker-restart-zfs run_job '"'$CI_JOB_ID'"'' '"'$CI_PIPELINE_ID'"' '"'$CI_COMMIT_SHA'"' '"'$node_name'"' '"'$ZFS_OPERATOR_NAMESPACE'"'
 
 }

--- a/pipeline/stages/5-infra-chaos/5I02-node-kubelet-restart-zfs
+++ b/pipeline/stages/5-infra-chaos/5I02-node-kubelet-restart-zfs
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-### Taint the node to run infra chaos test scripts
-node_name=$(ssh -o StrictHostKeyChecking=no $zfs_user@$zfs_ip -p $zfs_port -i /root/.ssh/id_rsa -o LogLevel=ERROR kubectl get nodes --no-headers | grep -v master | awk 'FNR==1 {print $1}')
-
 ## Define and initialize test-result specific variables.
 app_deploy_rc_val=1
 app_loadgen_rc_val=1
@@ -14,6 +11,10 @@ mkdir -p /root/.ssh
 touch /root/.ssh/id_rsa
 echo "$SSH_KEYS" > /root/.ssh/id_rsa
 chmod 600 /root/.ssh/id_rsa
+
+### Taint the node to run infra chaos test scripts
+node_name=$(ssh -o StrictHostKeyChecking=no $zfs_user@$zfs_ip -p $zfs_port -i /root/.ssh/id_rsa -o LogLevel=ERROR kubectl get nodes --no-headers | grep -v master | awk 'FNR==1 {print $1}')
+
 ssh -o StrictHostKeyChecking=no $zfs_user@$zfs_ip -p $zfs_port -i /root/.ssh/id_rsa -o LogLevel=ERROR 'cd e2e-nativek8s && bash pipeline/stages/5-infra-chaos/5I02-node-kubelet-restart-zfs run_job '"'$CI_JOB_ID'"'' '"'$CI_PIPELINE_ID'"' '"'$CI_COMMIT_SHA'"' '"'$node_name'"' '"'$ZFS_OPERATOR_NAMESPACE'"'
 
 }

--- a/pipeline/stages/5-infra-chaos/5I03-node-failure-zfs
+++ b/pipeline/stages/5-infra-chaos/5I03-node-failure-zfs
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-### Taint the node to run infra chaos test scripts
-node_name=$(ssh -o StrictHostKeyChecking=no $zfs_user@$zfs_ip -p $zfs_port -i /root/.ssh/id_rsa -o LogLevel=ERROR kubectl get nodes --no-headers | grep -v master | awk 'FNR==1 {print $1}')
-
 ## Define and initialize test-result specific variables.
 app_deploy_rc_val=1
 app_loadgen_rc_val=1
@@ -14,6 +11,10 @@ mkdir -p /root/.ssh
 touch /root/.ssh/id_rsa
 echo "$SSH_KEYS" > /root/.ssh/id_rsa
 chmod 600 /root/.ssh/id_rsa
+
+### Taint the node to run infra chaos test scripts
+node_name=$(ssh -o StrictHostKeyChecking=no $zfs_user@$zfs_ip -p $zfs_port -i /root/.ssh/id_rsa -o LogLevel=ERROR kubectl get nodes --no-headers | grep -v master | awk 'FNR==1 {print $1}')
+
 ssh -o StrictHostKeyChecking=no $zfs_user@$zfs_ip -p $zfs_port -i /root/.ssh/id_rsa -o LogLevel=ERROR 'cd e2e-nativek8s && bash pipeline/stages/5-infra-chaos/5I03-node-failure-zfs run_job '"'$CI_JOB_ID'"'' '"'$CI_PIPELINE_ID'"' '"'$CI_COMMIT_SHA'"' '"'$node_name'"' '"'$ZFS_OPERATOR_NAMESPACE'"'
 
 }


### PR DESCRIPTION
Signed-off-by: w3aman <aman.gupta@mayadata.io>

- Added a echo command to display k8s version of pipeline cluster

- without gettting SSH key update to /root/.ssh/id_rsa, we were trying to ssh into the nodes. Making that step after ssh keys update